### PR TITLE
Support configuring verilator path by $VERILATOR_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,14 @@ else()
 endif()
 
 # check verilator
-execute_process(
-    COMMAND bash -c "verilator -V|grep ROOT|grep verilator|awk '{print $3}'"
-    OUTPUT_VARIABLE verilator_root
-)
+if ("$ENV{VERILATOR_ROOT}" STREQUAL "")
+    execute_process(
+        COMMAND bash -c "verilator -V|grep ROOT|grep verilator|awk '{print $3}'"
+        OUTPUT_VARIABLE verilator_root
+    )
+else()
+    set(verilator_root $ENV{VERILATOR_ROOT})
+endif()
 
 if (NOT "${verilator_root}" STREQUAL "")
     include_directories(${verilator_root})


### PR DESCRIPTION
Sometimes there are multiple installation of verilator on a machine. It is not suitable to use `PATH` to figure out the installation path of verilator under this circumstance, thus a dedicated variable is required to be specified.
`VERILATOR_ROOT` is used to configure installation path [for verilator itself](https://verilator.org/guide/latest/install.html#eventual-installation-options), and it seems to be natural to use this to specify verilator installation path for us.