### PR TITLE
support high version of verilator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 # check verilator
 if ("$ENV{VERILATOR_ROOT}" STREQUAL "")
     execute_process(
-        COMMAND bash -c "verilator -V|grep ROOT|grep verilator|awk '{print $3}'"
+        COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
         OUTPUT_VARIABLE verilator_root
     )
 else()


### PR DESCRIPTION
In high version of verilator, command 'bash -c "verilator -V|grep ROOT|grep verilator' will output more than one line. We only need to select the first one. 
![image](https://github.com/user-attachments/assets/d825295a-977f-4b14-b601-818fb23b5af8)
