### PR TITLE
fix src/codegen/lib.cpp: ERROE --> MESSAGE

### DIFF
--- a/src/codegen/lib.cpp
+++ b/src/codegen/lib.cpp
@@ -62,7 +62,7 @@ namespace picker { namespace codegen {
             if (check_file_type(path, allow_file_types)) { // file
                 auto target_file = path;
                 if (!std::filesystem::exists(path) && !path.starts_with("/") && !fs_path.empty()) {
-                    PK_ERROR("Cannot find file: %s, try search in path: %s", path.c_str(), fs_path.c_str());
+                    PK_MESSAGE("Cannot find file: %s, try search in path: %s", path.c_str(), fs_path.c_str());
                     path = (std::filesystem::path(fs_path) / path).string();
                 }
                 if (!std::filesystem::exists(path)) PK_FATAL("File not found: %s\n", target_file.c_str());


### PR DESCRIPTION
# Description

Every time you search for rtl when packaging dut, an error will be reported:
`Cannot find file: ../../rtl/rtl/TLBNonBlock.sv, try search in path: /home/bdj/UnityChipForXiangShan/scripts/frontend_itlb`
Even though the file path is correct and can be found.

The problem is in /picker/src/codegen/lib.cpp: line 64:
                    `PK_ERROR("Cannot find file: %s, try search in path: %s", path.c_str(), fs_path.c_str());`
When searching for rtl, a check is performed. If the path does not exist, the path is a relative path, and fs_path is a non-empty string, an error will be reported and the search will be redirected to the specified path. In UnityChip, these three conditions are naturally met, so each time the dut is packaged, all rtl files will report this error.

## Fixes

Change PK_ERROR to PK_MESSAGE
