### PR TITLE
Update yaml-cpp CMakeLists version

### DIFF
--- a/third/yaml-cpp/CMakeLists.txt
+++ b/third/yaml-cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
-# 3.5 is actually available almost everywhere, but this a good minimum
-cmake_minimum_required(VERSION 3.4)
+# CMake 4.0 and above no longer support compatibility with versions earlier than 3.5
+cmake_minimum_required(VERSION 3.5)
 
 # enable MSVC_RUNTIME_LIBRARY target property
 # see https://cmake.org/cmake/help/latest/policy/CMP0091.html


### PR DESCRIPTION
# Description

This PR updates the `cmake_minimum_required` version in `third/yaml-cpp/CMakeLists.txt` from a deprecated value (`< 3.5`) to a minimum of `3.5`.  
This change addresses compatibility issues with CMake 4.0 and above, which have officially dropped support for versions earlier than 3.5.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
