### PR TITLE
Fix(cmake): Correctly select VERILATOR_ROOT

### DIFF
--- a/template/cpp/cmake/verilator.cmake
+++ b/template/cpp/cmake/verilator.cmake
@@ -26,7 +26,7 @@ function(XSPTarget)
 	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
 
 	execute_process(
-		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
+		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|tail -n 1|awk '{print $3}'"
 		OUTPUT_VARIABLE CMD_VERILATOR_ROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)

--- a/template/golang/cmake/verilator.cmake
+++ b/template/golang/cmake/verilator.cmake
@@ -21,7 +21,7 @@ function(XSGolangTarget)
 	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
 
 	execute_process(
-		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
+		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|tail -n 1|awk '{print $3}'"
 		OUTPUT_VARIABLE CMD_VERILATOR_ROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)

--- a/template/java/cmake/verilator.cmake
+++ b/template/java/cmake/verilator.cmake
@@ -21,7 +21,7 @@ function(XSJavaTarget)
 	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
 
 	execute_process(
-		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
+		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|tail -n 1|awk '{print $3}'"
 		OUTPUT_VARIABLE CMD_VERILATOR_ROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)

--- a/template/lib/cmake/verilator.cmake
+++ b/template/lib/cmake/verilator.cmake
@@ -4,7 +4,7 @@ if(SIMULATOR STREQUAL "verilator")
 
 	# Get VERILATOR_ROOT from verilator command output
 	execute_process(
-		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
+		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|tail -n 1|awk '{print $3}'"
 		OUTPUT_VARIABLE CMD_VERILATOR_ROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)

--- a/template/lua/cmake/verilator.cmake
+++ b/template/lua/cmake/verilator.cmake
@@ -21,7 +21,7 @@ function(XSPyTarget)
 	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
 
 	execute_process(
-		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
+		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|tail -n 1|awk '{print $3}'"
 		OUTPUT_VARIABLE CMD_VERILATOR_ROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)

--- a/template/python/cmake/verilator.cmake
+++ b/template/python/cmake/verilator.cmake
@@ -21,7 +21,7 @@ function(XSPyTarget)
 	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
 
 	execute_process(
-		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
+		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|tail -n 1|awk '{print $3}'"
 		OUTPUT_VARIABLE CMD_VERILATOR_ROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)

--- a/template/scala/cmake/verilator.cmake
+++ b/template/scala/cmake/verilator.cmake
@@ -21,7 +21,7 @@ function(XSScalaTarget)
 	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
 
 	execute_process(
-		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|head -n 1|awk '{print $3}'"
+		COMMAND bash -c "verilator -V|grep ROOT|grep verilator|tail -n 1|awk '{print $3}'"
 		OUTPUT_VARIABLE CMD_VERILATOR_ROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)


### PR DESCRIPTION
# Description

Modify the selection logic for `CMD_VERILATOR_ROOT` in `verilator.cmake`.

When using a Verilator distribution that is not installed from a package manager or compiled from source, such as the one provided by [oss-cad-suite](https://github.com/YosysHQ/oss-cad-suite-build), the output of `verilator -V` can be as follows:

```bash
Summary of configuration:
  Compiled in defaults if not in environment:
    SYSTEMC           =
    SYSTEMC_ARCH      =
    SYSTEMC_INCLUDE   =
    SYSTEMC_LIBDIR    =
    VERILATOR_ROOT    = /yosyshq/share/verilator
    SystemC system-wide = 0

Environment:
    MAKE              =
    PERL              =
    PYTHON3           =
    SYSTEMC           =
    SYSTEMC_ARCH      =
    SYSTEMC_INCLUDE   =
    SYSTEMC_LIBDIR    =
    VERILATOR_BIN     =
    VERILATOR_ROOT    = /opt/oss-cad-suite/share/verilator
```

This output provides two `VERILATOR_ROOT` paths. The one under the `Environment` section is the intended path for this setup.

The previous selection logic would incorrectly choose the first `VERILATOR_ROOT` it found, which was the incorrect one from the `Compiled in defaults` section.

This patch updates the logic to prioritize the `VERILATOR_ROOT` from the `Environment` section. It will only fall back to the `Compiled in defaults` path if the environment one is not available.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I tested the Python package export by running the Adder, RandomGenerator, and Cache examples across several Verilator setups: oss-cad-suite, package manager (v5.006), and source builds (v4.228 & v5.038).


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
