### PR TITLE
Fix gsim resolve -v flag failed to propagate arguments to gsim 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       VERIBLE_VERSION: v0.0-4007-g98bdb38a
       BUILD_XSPCOMM_SWIG: python,java
+      VERILATOR_VERSION: v5.018
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,17 +62,44 @@ jobs:
           rm -rf /tmp/swig
 
       - name: Build and install Verilator from source
-        env:
-          VERILATOR_VERSION: v5.018
+        id: setup-verilator
+        run: |
+          set -euo pipefail
+          echo "VERILATOR_PREFIX=${HOME}/.cache/verilator/${VERILATOR_VERSION}" >> "$GITHUB_ENV"
+      
+      - name: Restore Verilator fakeroot cache
+        id: cache-verilator
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/verilator/${{ env.VERILATOR_VERSION }}
+          key: verilator-${{ matrix.os }}-${{ env.VERILATOR_VERSION }}-v1
+
+      - name: Use cached Verilator (if available)
+        if: steps.cache-verilator.outputs.cache-hit == 'true'
+        run: |
+          echo "${VERILATOR_PREFIX}/bin" >> "$GITHUB_PATH"
+          verilator --version || true
+
+      - name: Build and install Verilator into fakeroot
+        if: steps.cache-verilator.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           git clone https://github.com/verilator/verilator -b "${VERILATOR_VERSION}" --depth=1 /tmp/verilator
           cd /tmp/verilator
           autoconf
-          ./configure --prefix=/usr/local
+          ./configure --prefix="${VERILATOR_PREFIX}"
           make -j"$(nproc)"
-          sudo make install
+          make install
           rm -rf /tmp/verilator
+          echo "${VERILATOR_PREFIX}/bin" >> "$GITHUB_PATH"
+          verilator --version || true
+
+      - name: Save Verilator fakeroot cache (trusted contexts only)
+        if: steps.cache-verilator.outputs.cache-hit != 'true' && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/verilator/${{ env.VERILATOR_VERSION }}
+          key: verilator-${{ matrix.os }}-${{ env.VERILATOR_VERSION }}-v1
 
       - name: Install Verible (format + syntax)
         run: |
@@ -99,8 +127,7 @@ jobs:
         run: |
           make init
           # Ensure install prefix is /usr so files land in AppDir/usr
-          cmake . -B build DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL="$(nproc)" -DCMAKE_INSTALL_PREFIX=/usr
-          cmake --build build --parallel $(nproc)
+          cmake . -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL="$(nproc)" -DCMAKE_INSTALL_PREFIX=/usr
 
       - name: Install into AppDir (prepare artifact)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
         run: |
           make init
           # Ensure install prefix is /usr so files land in AppDir/usr
-          cmake . -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL="$(nproc)" -DCMAKE_INSTALL_PREFIX=/usr
+          cmake . -B build DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL="$(nproc)" -DCMAKE_INSTALL_PREFIX=/usr
+          cmake --build build --parallel $(nproc)
 
       - name: Install into AppDir (prepare artifact)
         run: |

--- a/src/parser/firrtl.cpp
+++ b/src/parser/firrtl.cpp
@@ -262,10 +262,19 @@ namespace picker { namespace parser {
                 // Check for port lines: "input clock : Clock" or "output result : UInt<32>"
                 auto input_pos = line.find("input ");
                 auto output_pos = line.find("output ");
-                auto pos = std::min(input_pos, output_pos);
+		size_t pos;
+                if (input_pos != std::string::npos && output_pos != std::string::npos) {
+                    pos = std::min(input_pos, output_pos);
+                } else if (input_pos != std::string::npos) {
+                    pos = input_pos;
+                } else if (output_pos != std::string::npos) {
+                    pos = output_pos;
+                } else {
+                    pos = std::string::npos;
+                }
                 if (pos != std::string::npos) {
-                    auto parse_line = line.substr(pos);
-                    PK_MESSAGE("Find: %s\n", parse_line.c_str());
+		    auto parse_line = line.substr(pos);
+                    PK_MESSAGE("Find: %s", parse_line.c_str());
                     std::vector<sv_signal_define> parsed_ports = parse_firrtl_port(parse_line);
                     for (const auto& port : parsed_ports) {
                         PK_MESSAGE("Find pin: %s", port.logic_pin.c_str());

--- a/src/parser/firrtl.cpp
+++ b/src/parser/firrtl.cpp
@@ -277,9 +277,7 @@ namespace picker { namespace parser {
                     PK_MESSAGE("Find: %s", parse_line.c_str());
                     std::vector<sv_signal_define> parsed_ports = parse_firrtl_port(parse_line);
                     for (const auto& port : parsed_ports) {
-                        PK_MESSAGE("Find pin: %s", port.logic_pin.c_str());
                         if (!port.logic_pin.empty()) {
-                            PK_MESSAGE("Push pin: %s", port.logic_pin.c_str());
                             ports.push_back(port);
                         }
                     }

--- a/template/lib/cmake/gsim.cmake
+++ b/template/lib/cmake/gsim.cmake
@@ -2,7 +2,8 @@ if(SIMULATOR STREQUAL "gsim")
 	add_definitions(-DUSE_GSIM)
 	add_definitions(-DNO_SV_VPI)
 	message(STATUS "gsim simulator generate source files")
-	set(SIMULATOR_FLAGS "$ENV{GSIM_FLAGS}")
+	string(REPLACE ";" " " GSIM_FLAGS "$ENV{SIMULATOR_FLAGS}")
+	separate_arguments(GSIM_FLAG_LIST UNIX_COMMAND "${GSIM_FLAGS}")
 	# find cmd gsim and generate source files
 	find_program(GSIM_EXECUTABLE gsim)
 	if(NOT GSIM_EXECUTABLE)
@@ -15,7 +16,7 @@ if(SIMULATOR STREQUAL "gsim")
 	execute_process(
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 			COMMAND
-				${GSIM_EXECUTABLE} ${SIMULATOR_FLAGS} --dir=_SRC
+				${GSIM_EXECUTABLE} ${GSIM_FLAG_LIST} --dir=_SRC
 				${CMAKE_CURRENT_SOURCE_DIR}/${ModuleName}.fir
 			COMMAND_ECHO STDOUT
 			)

--- a/test/test_picker_utils.cpp
+++ b/test/test_picker_utils.cpp
@@ -18,7 +18,7 @@ int main() {
   assert(picker::ltrim(string("  hi")) == "hi");
   assert(picker::rtrim(string("hi  ")) == "hi");
   assert(picker::trim(string("  hi \t")) == "hi");
-  assert(picker::trim(string("--x--"), string("-")) == string("x--"));
+  assert(picker::trim(string("--x--"), string("-")) == string("x"));
 
   // strsplit basic
   auto ss = picker::strsplit(string("a b  c"));


### PR DESCRIPTION
# Description

This PR introduces performance improvements to the FIRRTL file parsing logic in firrtl.cpp and resolves a bug where the -v flag failed to propagate arguments to gsim.

## Type of change
- [x] Bug fix (Corrected the argument parsing logic to ensure the -v flag properly passes arguments to gsim.)
- [x] Breaking change (Refactored the firrtl file  parsing function to significantly reduce parsing time, especially for large design files.

# How Has This Been Tested?
run picker command like this 
`picker export SimTop.fir --sim gsim -V "--supernode-max-size=2;--cpp-max-size-KB=8192"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
