### PR TITLE
Fix the bug of getting wrong verilator_root in the makefile of mem_direct

### DIFF
--- a/template/mem_direct/Makefile
+++ b/template/mem_direct/Makefile
@@ -5,7 +5,7 @@ TOP_NAME?=
 
 {% if __SIMULATOR__ == "verilator" %}
 # Use the last VERILATOR_ROOT reported by `verilator -V`
-V_ROOT := $(shell verilator -V | awk '/VERILATOR_ROOT/ {v=$$3} END{print v}')
+V_ROOT := $(shell verilator -V | grep ROOT | grep verilator | tail -n 1 | awk '{print $3}')
 
 CXXFLAGS += -I ${V_ROOT}/include -I ${V_ROOT}/include/vltstd/ \
 		-I ../build/DPI${TOP_NAME} \


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
