### PR TITLE
fix(mem_direct): update getting verilator_root function in the makefi…

### DIFF
--- a/template/mem_direct/Makefile
+++ b/template/mem_direct/Makefile
@@ -5,7 +5,7 @@ TOP_NAME?=
 
 {% if __SIMULATOR__ == "verilator" %}
 # Use the last VERILATOR_ROOT reported by `verilator -V`
-V_ROOT := $(shell verilator -V | grep ROOT | grep verilator | tail -n 1 | awk '{print $3}')
+V_ROOT := $(shell verilator -V | grep ROOT | grep verilator | tail -n 1 | awk '{print $$3}')
 
 CXXFLAGS += -I ${V_ROOT}/include -I ${V_ROOT}/include/vltstd/ \
 		-I ../build/DPI${TOP_NAME} \


### PR DESCRIPTION
# Description

This PR fixes a bug in the Makefile for the mem_direct template where the verilator_root path was being incorrectly extracted from the verilator -V command output.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
