### PR TITLE
chore(docker): switch default Python to 3.11 and add time/node tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     curl \
     vim \
+    time \
     software-properties-common \
-    python3 \
-    python3-pip \
-    python3-dev \
     libpcre3-dev \
     libpcre2-dev \
     pkg-config \
@@ -42,6 +40,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     help2man && \
     ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update && apt-get install -y --no-install-recommends nodejs python3.11 python3.11-dev python3.11-venv && \
+    python3.11 -m ensurepip --upgrade && \
+    python3.11 -m pip install --upgrade pip && \
+    ln -sf /usr/bin/python3.11 /usr/local/bin/python3 && \
+    ln -sf /usr/local/bin/pip3.11 /usr/local/bin/pip3 && \
+    npm install -g npm@10 && \
     rm -rf /var/lib/apt/lists/*
 
 # SWIG
@@ -94,6 +102,5 @@ RUN useradd -m -s /bin/bash user && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     chown -R user:user /workspace
 
-USER user
 SHELL ["/bin/bash", "-c"]
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tzdata \
     build-essential \
     git \
-    sudo \
     wget \
     curl \
     vim \
@@ -42,14 +41,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg-reconfigure -f noninteractive tzdata && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt-get update && apt-get install -y --no-install-recommends nodejs python3.11 python3.11-dev python3.11-venv && \
+ENV NVM_DIR=/usr/local/nvm
+ENV NODE_VERSION=20.12.2
+
+RUN mkdir -p $NVM_DIR && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
+    . $NVM_DIR/nvm.sh && \
+    nvm install $NODE_VERSION && \
+    nvm alias default $NODE_VERSION && \
+    nvm use default && \
+    npm install -g npm@10 && \
+    chmod -R 777 $NVM_DIR && \
+    echo 'export NVM_DIR="/usr/local/nvm"' >> /etc/bash.bashrc && \
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/bash.bashrc
+
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+RUN add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update && apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv && \
     python3.11 -m ensurepip --upgrade && \
     python3.11 -m pip install --upgrade pip && \
     ln -sf /usr/bin/python3.11 /usr/local/bin/python3 && \
     ln -sf /usr/local/bin/pip3.11 /usr/local/bin/pip3 && \
-    npm install -g npm@10 && \
     rm -rf /var/lib/apt/lists/*
 
 # SWIG
@@ -96,11 +109,7 @@ WORKDIR /workspace
 COPY . /workspace/picker
 RUN cd /workspace/picker && make && make install && make clean
 
-# Create a non-root user for interactive use
-RUN useradd -m -s /bin/bash user && \
-    adduser user sudo && \
-    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    chown -R user:user /workspace
+
 
 SHELL ["/bin/bash", "-c"]
 WORKDIR /workspace


### PR DESCRIPTION
# Description

This PR updates the Docker image to use Python 3.11 as the default Python runtime and adds missing tooling for development workflows.

- remove legacy python3, python3-pip, and python3-dev base packages
- install python3.11, python3.11-dev, and python3.11-venv
- bootstrap pip for Python 3.11 and set python3/pip3 alternatives to 3.11
- add Node.js 20 and upgrade npm
- add time package to base dependencies

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
docker run -it --rm --name picker ghcr.io/xs-mlvp/picker:latest
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
