### PR TITLE
refactor(sv): removed the deduplication step for filelist

### DIFF
--- a/src/parser/sv.cpp
+++ b/src/parser/sv.cpp
@@ -17,7 +17,6 @@
 #include <fstream>
 #include <sstream>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace picker { namespace parser {
 
@@ -116,43 +115,18 @@ namespace picker { namespace parser {
             }
         }
 
-        void add_unique_source_arg(const std::string &file, std::vector<std::string> &args,
-                                   std::unordered_set<std::string> &seen_sources)
+        void append_source_arg(const std::string &file, std::vector<std::string> &args)
         {
-            auto normalized = normalize_path(file);
-            if (seen_sources.insert(normalized).second) { args.push_back(normalized); }
+            args.push_back(normalize_path(file));
         }
 
-        void collect_filelist_source_paths(const std::filesystem::path &filelist_path,
-                                           std::unordered_set<std::string> &sources)
-        {
-            std::ifstream stream(filelist_path);
-            if (!stream.is_open()) { return; }
-
-            const auto base_dir = std::filesystem::absolute(filelist_path).parent_path();
-            std::string line;
-            while (std::getline(stream, line)) {
-                auto entry = strip_comment_and_trim(line);
-                if (entry.empty()) { continue; }
-
-                auto path = std::filesystem::path(entry);
-                if (path.is_relative()) { path = base_dir / path; }
-                if (std::filesystem::is_regular_file(path) && is_verilog_src(path.string())) {
-                    sources.insert(normalize_path(path));
-                }
-            }
-        }
-
-        void append_filelists_to_driver_args(const std::vector<std::string> &filelists, std::vector<std::string> &args,
-                                             std::unordered_set<std::string> &seen_sources)
+        void append_filelists_to_driver_args(const std::vector<std::string> &filelists, std::vector<std::string> &args)
         {
             std::vector<std::string> direct_files;
             for (const auto &filelist : filelists) {
                 if (filelist.ends_with(".txt") || filelist.ends_with(".f")) {
                     args.push_back("-F");
-                    const auto normalized_filelist = normalize_path(filelist);
-                    args.push_back(normalized_filelist);
-                    collect_filelist_source_paths(normalized_filelist, seen_sources);
+                    args.push_back(normalize_path(filelist));
                     continue;
                 }
 
@@ -161,13 +135,12 @@ namespace picker { namespace parser {
                 while (std::getline(ss, token, ',')) { append_direct_filelist_entry(token, direct_files); }
             }
 
-            for (const auto &file : direct_files) { add_unique_source_arg(file, args, seen_sources); }
+            for (const auto &file : direct_files) { append_source_arg(file, args); }
         }
 
-        void append_explicit_files_to_driver_args(const std::vector<std::string> &files, std::vector<std::string> &args,
-                                                  std::unordered_set<std::string> &seen_sources)
+        void append_explicit_files_to_driver_args(const std::vector<std::string> &files, std::vector<std::string> &args)
         {
-            for (const auto &file : files) { add_unique_source_arg(file, args, seen_sources); }
+            for (const auto &file : files) { append_source_arg(file, args); }
         }
 
         std::vector<const char *> build_argv(const std::vector<std::string> &args)
@@ -298,9 +271,8 @@ namespace picker { namespace parser {
                 args.push_back("vcs");
             }
 
-            std::unordered_set<std::string> seen_sources;
-            if (use_filelists) { append_filelists_to_driver_args(opts.filelists, args, seen_sources); }
-            append_explicit_files_to_driver_args(opts.file, args, seen_sources);
+            if (use_filelists) { append_filelists_to_driver_args(opts.filelists, args); }
+            append_explicit_files_to_driver_args(opts.file, args);
 
             auto argv = build_argv(args);
             if (!driver.parseCommandLine((int)argv.size(), argv.data())) {
@@ -354,7 +326,7 @@ namespace picker { namespace parser {
             }
 
             Driver driver;
-            prepare_driver(driver, opts, has_explicit_requests);
+            prepare_driver(driver, opts, !opts.filelists.empty());
             if (has_explicit_requests) {
                 for (const auto &[module_name, _] : requested_module_counts) {
                     resolved_module_names.push_back(module_name);

--- a/test/test_parser_sv_unit.cpp
+++ b/test/test_parser_sv_unit.cpp
@@ -162,6 +162,40 @@ namespace {
         fs::remove_all(base);
     }
 
+    void test_filelist_dependencies_are_used_without_explicit_module_name()
+    {
+        namespace fs = std::filesystem;
+        const fs::path base = fs::temp_directory_path() / "picker_test_sv_filelist_default_top";
+        fs::remove_all(base);
+        fs::create_directories(base);
+
+        write_text(base / "defs.v",
+                   "`define IMPLICIT_TOP_W 6\n");
+        write_text(base / "implicit_top.v",
+                   "module ImplicitTop(input logic [`IMPLICIT_TOP_W-1:0] data);\n"
+                   "endmodule\n");
+        write_text(base / "filelist.f",
+                   "defs.v\n");
+
+        picker::export_opts opts {};
+        opts.file = {(base / "implicit_top.v").string()};
+        opts.filelists = {(base / "filelist.f").string()};
+
+        std::vector<picker::sv_module_define> modules;
+        picker::parser::sv(opts, modules);
+
+        assert(modules.size() == 1);
+        assert(modules.front().module_name == "ImplicitTop");
+        assert(opts.target_module_name == "ImplicitTop");
+
+        const auto &pin_data = find_pin(modules.front(), "data");
+        assert(pin_data.logic_pin_type == "input");
+        assert(pin_data.logic_pin_hb == 5);
+        assert(pin_data.logic_pin_lb == 0);
+
+        fs::remove_all(base);
+    }
+
     void test_filelist_order_wins_when_explicit_file_is_duplicate()
     {
         namespace fs = std::filesystem;
@@ -237,6 +271,7 @@ int main()
     test_filelist_include_define_and_math();
     test_default_module_is_last_declared();
     test_filelist_macro_defines_are_shared_across_sources();
+    test_filelist_dependencies_are_used_without_explicit_module_name();
     test_filelist_order_wins_when_explicit_file_is_duplicate();
     test_missing_child_modules_do_not_block_top_port_extraction();
     return 0;


### PR DESCRIPTION
This pull request simplifies the handling of source files and filelists in the SystemVerilog parser by removing logic that deduplicated source files and tracked them with a set. Instead, all specified source files are now appended directly to the driver arguments. Additionally, a new unit test is added to ensure that filelist dependencies are correctly used even when no explicit module name is provided.

**Refactoring and simplification:**

* Removed the use of `std::unordered_set` and related deduplication logic for source files in `src/parser/sv.cpp`, simplifying the process of appending source files and filelists to driver arguments. (`src/parser/sv.cpp`) [[1]](diffhunk://#diff-ed889ed724211cc59f3d43c199d9dd0a8f194de2ece75de623c83d0cc4561dceL20) [[2]](diffhunk://#diff-ed889ed724211cc59f3d43c199d9dd0a8f194de2ece75de623c83d0cc4561dceL119-R129) [[3]](diffhunk://#diff-ed889ed724211cc59f3d43c199d9dd0a8f194de2ece75de623c83d0cc4561dceL164-R143) [[4]](diffhunk://#diff-ed889ed724211cc59f3d43c199d9dd0a8f194de2ece75de623c83d0cc4561dceL301-R275)
* Updated function signatures and internal logic to reflect the removal of deduplication, passing only the required arguments. (`src/parser/sv.cpp`) [[1]](diffhunk://#diff-ed889ed724211cc59f3d43c199d9dd0a8f194de2ece75de623c83d0cc4561dceL119-R129) [[2]](diffhunk://#diff-ed889ed724211cc59f3d43c199d9dd0a8f194de2ece75de623c83d0cc4561dceL164-R143) [[3]](diffhunk://#diff-ed889ed724211cc59f3d43c199d9dd0a8f194de2ece75de623c83d0cc4561dceL301-R275)

**Testing improvements:**

* Added a new unit test `test_filelist_dependencies_are_used_without_explicit_module_name` to verify that filelist dependencies are correctly handled when no explicit module name is specified. (`test/test_parser_sv_unit.cpp`) [[1]](diffhunk://#diff-1b4cedb04d7b009555b84fe23df93b3b650e5bec8a6fff9ea650824256a62d60R165-R198) [[2]](diffhunk://#diff-1b4cedb04d7b009555b84fe23df93b3b650e5bec8a6fff9ea650824256a62d60R274)

**Minor logic update:**

* Adjusted the argument passed to `prepare_driver` to more accurately reflect filelist usage. (`src/parser/sv.cpp`)