### PR TITLE
UVS support in picker (phase 1)

### DIFF
--- a/example/DualPortStackCb/example.cpp
+++ b/example/DualPortStackCb/example.cpp
@@ -142,6 +142,9 @@ int main()
 {
     UTdual_port_stack dut;
     dut.InitClock("clk");
+    dut.rst = 1;
+    dut.Step(1);
+    dut.rst = 0;
     testStack(&dut);
     dut.Finish();
     return 0;

--- a/example/DualPortStackCb/example.py
+++ b/example/DualPortStackCb/example.py
@@ -120,5 +120,8 @@ def test_stack(stack):
 if __name__ == "__main__":
     dut = DUTdual_port_stack()
     dut.InitClock("clk")
+    dut.rst.value = 1
+    dut.Step(1)
+    dut.rst.value = 0
     test_stack(dut)
     dut.Finish()

--- a/example/DualPortStackCb/release-uvs.sh
+++ b/example/DualPortStackCb/release-uvs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+rm -rf picker_out_dps/
+
+./build/bin/picker export example/DualPortStackCb/dual_port_stack.v --sim uvs --autobuild false -w DualPortStackCb.usdb $@ --tdir picker_out_dps
+# if python in $@, then it will generate python binding
+if [[ $@ == *"python"* ]]; then
+    if [[ "$async" != "" ]]; then
+        cp example/DualPortStackCb/example_async.py picker_out_dps/python/example.py
+    else
+        cp example/DualPortStackCb/example.py picker_out_dps/python/
+    fi
+elif [[ $@ == *"java"* ]]; then
+    cp example/DualPortStackCb/example.java picker_out_dps/java/
+elif [[ $@ == *"scala"* ]]; then
+    cp example/DualPortStackCb/example.scala picker_out_dps/scala/
+elif [[ $@ == *"golang"* ]]; then
+    cp example/DualPortStackCb/example.go picker_out_dps/golang/
+else
+    cp example/DualPortStackCb/example.cpp picker_out_dps/cpp/
+fi
+
+cd picker_out_dps && make EXAMPLE=ON VERBOSE=ON CFLAGS=-g
+
+if [[ $@ == *"python"* ]]; then
+    echo "'cannot allocate memory in static TLS block'error for UVS is expected, please ignore it"
+    LD_PRELOAD=./UT_dual_port_stack/libUTdual_port_stack.so python3 example.py
+fi
+

--- a/src/codegen/lib.cpp
+++ b/src/codegen/lib.cpp
@@ -157,6 +157,8 @@ namespace picker { namespace codegen {
                 extra += "-I" + dir;
             } else if (simulator == "vcs") {
                 extra += "+incdir+" + dir;
+            } else if (simulator == "uvs") {
+                extra += "-include " + dir;
             }
         }
         if (extra.empty()) { return; }

--- a/src/codegen/sv.cpp
+++ b/src/codegen/sv.cpp
@@ -160,6 +160,16 @@ namespace picker { namespace codegen {
                                    "  end",
                                    data);
                 }
+            } else if (simulator == "uvs") {
+                if (wave_file_name.length() > 0) {
+                    if (wave_file_name.ends_with(".usdb") == false) PK_FATAL("USDB trace file must be .usdb format.\n");
+                    sv_dump_wave =
+                        env.render("  initial begin\n"
+                                   "    $usdbDumpfile(\"{{__WAVE_FILE_NAME__}}\");\n"
+                                   "    $usdbDumpvars(0, {{__TOP_MODULE_NAME__}}_top{{__DUMP_VAR_OPTIONS__}});\n"
+                                   "  end",
+                                   data);
+                }
             } else {
                 PK_FATAL("Unsupported simulator: %s\n", simulator.c_str());
             }

--- a/src/parser/parser_map.cpp
+++ b/src/parser/parser_map.cpp
@@ -18,6 +18,7 @@ namespace picker{namespace parser {
 
     std::map<std::string, std::function<int(picker::export_opts &opts, std::vector<picker::sv_module_define> &external_pin)>> inputParser = {
         {"vcs", picker::parser::sv},
+        {"uvs", picker::parser::sv},
         {"verilator", picker::parser::sv},
         {"gsim", picker::parser::firrtl}
     };

--- a/template/cpp/cmake/uvs.cmake
+++ b/template/cpp/cmake/uvs.cmake
@@ -1,0 +1,105 @@
+add_definitions(-DUSE_UVS)
+
+
+function(search_libs afound rlibs)
+    set(libs_list ${ARGN})
+    set(all_found TRUE)
+    set(libs "")
+    foreach(lib ${libs_list})
+        find_library(LIB_${lib} ${lib})
+        if (NOT LIB_${lib})
+            set(all_found FALSE)
+            break()
+        else()
+            message(STATUS "Found ${lib}: ${LIB_${lib}}")
+            set(libs "${libs} -l${lib}")
+        endif()
+    endforeach()
+    set(${afound} ${all_found} PARENT_SCOPE)
+    set(${rlibs} ${libs} PARENT_SCOPE)
+endfunction()
+
+
+function(XSPTarget)
+
+	cmake_parse_arguments(
+		XSP
+		""
+		"RTL_MODULE_NAME;EXECUTABLE_NAME"
+		"CUSTOM_LIBS;CUSTOM_LINK_OPTIONS"
+		""
+		${ARGN}
+	)
+	add_definitions(-DUSE_UVS)
+
+	if (NOT DEFINED XSP_RTL_MODULE_NAME)
+		message(FATAL_ERROR "RTL_MODULE_NAME not defined")
+	endif()
+
+	if (NOT DEFINED XSP_EXECUTABLE_NAME)
+		message(FATAL_ERROR "EXECUTABLE_NAME not defined")
+	endif()
+
+	set(RTLModuleName ${XSP_RTL_MODULE_NAME})
+	set(ExecutableName ${XSP_EXECUTABLE_NAME})
+	set(CustomLibs ${XSP_CUSTOM_LIBS})
+	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
+
+	# Find UVS
+	if(DEFINED ENV{UVS_HOME})
+		set(UVS_HOME $ENV{UVS_HOME})
+		message(STATUS "Find UVS root: ${UVS_HOME}")
+	else()
+		message(FATAL_ERROR "Cannot find uvs, please install (uvs)")
+	endif()
+
+	# Find UVD
+	if(DEFINED ENV{UVD_HOME})
+		set(UVD_HOME $ENV{UVD_HOME})
+		message(STATUS "Find UVD root: ${UVD_HOME}")
+	else()
+		message(FATAL_ERROR "Cannot find uvd, please install (uvd)")
+	endif()
+
+	# Build the cpp wrapper
+	include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+	add_library(UT${RTLModuleName} SHARED IMPORTED)
+	set_property(
+		TARGET UT${RTLModuleName}
+		PROPERTY IMPORTED_LOCATION
+						 ${CMAKE_CURRENT_SOURCE_DIR}/libUT${RTLModuleName}.so)
+
+	include_directories(${UVS_HOME}/include)
+	execute_process(
+		COMMAND
+			${CMAKE_COMMAND} -E copy
+			${CMAKE_CURRENT_SOURCE_DIR}/libDPI${RTLModuleName}.so
+			${CMAKE_CURRENT_BINARY_DIR}/libDPI${RTLModuleName}.so
+		COMMAND
+			${CMAKE_COMMAND} -E copy_directory
+			${CMAKE_CURRENT_SOURCE_DIR}/libDPI${RTLModuleName}.so.db
+			${CMAKE_CURRENT_BINARY_DIR}/libDPI${RTLModuleName}.so.db)
+
+	add_library(DPI${RTLModuleName} SHARED IMPORTED)
+	set_property(
+		TARGET DPI${RTLModuleName}
+		PROPERTY IMPORTED_LOCATION
+						 ${CMAKE_CURRENT_BINARY_DIR}/libDPI${RTLModuleName}.so)
+
+	# Build the test executable
+	add_executable(${ExecutableName} UT_${RTLModuleName}.cpp)
+	target_link_libraries(${ExecutableName} UT${RTLModuleName} DPI${RTLModuleName} xspcomm ${CustomLibs} ${CMAKE_DL_LIBS})
+	search_libs(ALL_FOUND LIBS zerosoft_rt_stubs m c pthread numa dl)
+	target_link_options(
+		${ExecutableName}
+		PRIVATE
+		-L./
+		-Wl,--unresolved-symbols=ignore-in-shared-libs
+		-Wl,-rpath={{__XSPCOMM_LIB__}}
+		-Wl,-rpath=~/.local/lib
+		-Wl,-rpath=/usr/local/lib
+		-Wl,--as-need
+		${LIBS}
+		${CustomLinkOptions})
+
+endfunction()

--- a/template/lib/CMakeLists.txt
+++ b/template/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 
 include(verilator)
 include(vcs)
+include(uvs)
 include(gsim)
 
 # Add CUSTOM_INCLUDE_FILES as target

--- a/template/lib/cmake/uvs.cmake
+++ b/template/lib/cmake/uvs.cmake
@@ -1,0 +1,78 @@
+if(SIMULATOR STREQUAL "uvs")
+
+	add_definitions(-DUSE_UVS)
+
+	# Find UVS
+	if(DEFINED ENV{UVS_HOME})
+		set(UVS_HOME $ENV{UVS_HOME})
+		message(STATUS "Find UVS root: ${UVS_HOME}")
+	else()
+		message(FATAL_ERROR "Cannot find ENV{UVS_HOME}, please install (uvs)")
+	endif()
+
+	# Find UVD
+	if(DEFINED ENV{UVD_HOME})
+		set(VERDI_HOME $ENV{UVD_HOME})
+		message(STATUS "Find UVD root: ${UVD_HOME}")
+	else()
+		message(FATAL_ERROR "Cannot find ENV{UVD_HOME}, please install (uvd) or set ENV{UVD_HOME}")
+	endif()
+
+	# Add UVS include path
+	include_directories(${UVS_HOME}/include)
+
+	# Add VCS magic
+	set(CMAKE_EXE_LINKER_FLAGS
+			"${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=1048576")
+
+	# Copy all source files to build directory
+	file(GLOB_RECURSE SOURCES "*.sv" "*.v" "*.f")
+	file(COPY ${SOURCES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+	# CFLAGS Detect IF CFLAGS is not empty, add -cflags to VCS compile
+	set(SIMULATOR_CFLAGS "")
+	if(NOT "${CFLAGS}" STREQUAL "")
+		# add -CFLAGS to VCS compile
+		set(SIMULATOR_CFLAGS "-cflags;${CFLAGS}")
+		message(STATUS "UVS CFLAGS: ${CFLAGS}")
+	endif()
+	
+	# if vpi is enabled, add SIMULATOR_FLAGS '+vpi' and '-debug_access+all'
+	if(${VPI} STREQUAL "ON")
+		set(SIMULATOR_FLAGS "${SIMULATOR_FLAGS};-debug cbk")
+	endif()
+
+
+	# Using VCS compile
+		execute_process(
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			COMMAND
+                uvs -ddb -debug r -sv -Xair opt.jemalloc=0 -Xair slave_mode -Xair sim_entry=UvsMain -l uvs_compile.log
+                -top ${ModuleName}_top -timescale=1ns/1ps    
+                ${ModuleName}_top.sv ${ModuleName}.v -f filelist.f    
+                -o libDPI${ModuleName}.so                              
+                ${SIMULATOR_FLAGS}                                                                 
+                -cflags ${SIMULATOR_CFLAGS})
+
+	# Set VCS DPI library as imported library
+	link_directories(${CMAKE_CURRENT_SOURCE_DIR})
+	add_library(DPI${ModuleName} SHARED IMPORTED)
+	set_target_properties(DPI${ModuleName} PROPERTIES IMPORTED_LOCATION libDPI${ModuleName}.so)
+
+	# Compile libUT wrapper with VCS DPI library
+	include_directories(${CMAKE_CURRENT_BINARY_DIR})
+	add_library(${ModuleName} SHARED dut_base)
+	target_link_libraries(${ModuleName} PRIVATE DPI${ModuleName})
+	target_link_options(${ModuleName} PRIVATE -Wl,-rpath,./)
+
+	# Copy libDPI${ModuleName}.so.daidir directory to build directory
+	add_custom_command(
+		TARGET ${ModuleName}
+		POST_BUILD
+		COMMAND
+			${CMAKE_COMMAND} -E copy_directory
+			${CMAKE_CURRENT_BINARY_DIR}/libDPI${ModuleName}.so.db
+			${CMAKE_BINARY_DIR}/UT_${ModuleName}/libDPI${ModuleName}.so.db
+		COMMAND touch ${CMAKE_BINARY_DIR}/UT_${ModuleName}/UT_${ModuleName}_dpi.hpp)
+
+endif()

--- a/template/lib/dut_base.cpp
+++ b/template/lib/dut_base.cpp
@@ -125,6 +125,108 @@ uint64_t DutVcsBase::NativeSignalAddr(const char *name){
 
 #endif
 
+#if defined(USE_UVS)
+
+DutUvsBase::DutUvsBase()
+{
+    // XXFatal("UVS does not support no-args constructor");
+    exit(-1);
+}
+
+DutUvsBase::DutUvsBase(int argc, char **argv)
+{
+    // save argc and argv for debug
+    this->argc = argc;
+    this->argv = argv;
+    this->init(argc, argv);
+};
+
+void DutUvsBase::init(int argc, char **argv)
+{
+    // initialize context
+    UvsMain(argc, argv);
+
+    // set cycle to 0
+    UvsInit();
+    svSetScope(svGetScopeFromName(this->sv_scope.c_str()));
+
+    // set cycle pointer to 0
+    this->cycle               = 0;
+    this->cycle_hl            = 0;
+    this->uvs_clock_period[0] = {{__VCS_CLOCK_PERIOD_HIGH__}};
+    this->uvs_clock_period[1] = {{__VCS_CLOCK_PERIOD_LOW__}};
+    this->uvs_clock_period[2] = {{__VCS_CLOCK_PERIOD_LOW__}} + {{__VCS_CLOCK_PERIOD_HIGH__}};
+}
+
+DutUvsBase::~DutUvsBase() {};
+
+int DutUvsBase::Step(uint64_t ncycle, bool dump)
+{
+    if (!dump) {
+        // assert(ncycle == 0);
+        UvsRunUntil(cycle);
+        return 0;
+    }
+
+    // set cycle pointer
+    cycle_hl += ncycle;
+    if (likely(ncycle == 1))
+        cycle += uvs_clock_period[cycle_hl & 1];
+    else
+        cycle += (ncycle >> 1) * uvs_clock_period[2] + (ncycle & 1) * uvs_clock_period[cycle_hl & 1];
+
+    // run simulation
+    UvsRunUntil(cycle);
+    return 0;
+};
+
+int DutUvsBase::Finish()
+{
+    // Finish VCS context
+    finish_{{__LIB_DPI_FUNC_NAME_HASH__}}();
+    return 0;
+};
+
+void DutUvsBase::SetWaveform(const char *filename)
+{
+    XInfo("UVS waveform is not supported");
+};
+void DutUvsBase::SetCoverage(const char *filename)
+{
+    XInfo("UVS coverage is not supported");
+};
+void DutUvsBase::FlushWaveform()
+{
+    XInfo("UVS waveform is not supported");
+};
+bool DutUvsBase::ResumeWaveformDump()
+{
+    XInfo("UVS waveform is not supported");
+    return true;
+};
+bool DutUvsBase::PauseWaveformDump()
+{
+    XInfo("UVS waveform is not supported");
+    return true;
+};
+void DutUvsBase::WaveformEnable(bool enable)
+{
+    XInfo("UVS waveform is not supported");
+};
+int DutUvsBase::CheckPoint(const char *filename)
+{
+    XFatal("UVS checkpoint is not supported");
+};
+int DutUvsBase::Restore(const char *filename)
+{
+    XFatal("UVS restore is not supported");
+};
+uint64_t DutUvsBase::NativeSignalAddr(const char *name){
+    XFatal("UVS NativeSignalAddr is not supported");
+    return 0;
+};
+
+#endif // USE_UVS
 
 #if defined(USE_GSIM)
 DutGSimBase::~DutGSimBase()
@@ -647,6 +749,8 @@ void DutUnifiedBase::init(int argc, const char **argv)
         this->dut = new DutVerilatorBase(this->argc, this->argv);
 #elif defined(USE_VCS)
         this->dut = new DutVcsBase(this->argc, this->argv);
+#elif defined(USE_UVS)
+        this->dut = new DutUvsBase(this->argc, this->argv);
 #elif defined(USE_GSIM)
         this->dut = new DutGSimBase(this->argc, this->argv);
 #endif
@@ -655,7 +759,7 @@ void DutUnifiedBase::init(int argc, const char **argv)
         return;
     }
 
-#ifndef USE_VCS
+#if !defined(USE_VCS) && !defined(USE_UVS)
     // get dynamic library path from argv
     if (this->argc == 0) { XFatal("Shared DPI Library Path is required for Simulator"); }
 

--- a/template/lib/dut_base.hpp
+++ b/template/lib/dut_base.hpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <initializer_list>
 
-#if defined(USE_VERILATOR) || defined(USE_VCS)
+#if defined(USE_VERILATOR) || defined(USE_VCS) || defined(USE_UVS)
 #include <svdpi.h>
 #endif
 
@@ -164,6 +164,42 @@ public:
 
 #endif
 
+#if defined(USE_UVS)
+extern "C" {
+int UvsMain(int argc, char **argv);
+void UvsInit();
+void UvsRunUntil(uint64_t);
+void UvsRun(uint64_t);
+void finish_{{__LIB_DPI_FUNC_NAME_HASH__}}();
+}
+
+class DutUvsBase : public DutBase
+{
+protected:
+    uint64_t cycle_hl;
+    uint64_t uvs_clock_period[3];
+
+public:
+    std::string sv_scope = "{{__TOP_MODULE_NAME__}}_top";
+    void init(int, char **);
+    DutUvsBase(int argc, char **argv);
+    [[deprecated("VCS does not support no-args constructor")]] DutUvsBase();
+    ~DutUvsBase();
+    int Step(uint64_t cycle, bool dump);
+    int Finish();
+    void SetWaveform(const char *filename);
+    void FlushWaveform();
+    bool ResumeWaveformDump();
+    bool PauseWaveformDump();
+    void WaveformEnable(bool enable);
+    void SetCoverage(const char *filename);
+    int CheckPoint(const char *filename);
+    int Restore(const char *filename);
+    uint64_t NativeSignalAddr(const char *name);
+};
+
+#endif
+
 char *locateLibPath();
 
 class DutUnifiedBase
@@ -189,6 +225,8 @@ protected:
     DutVerilatorBase *dut;
 #elif defined(USE_VCS)
     DutVcsBase *dut;
+#elif defined(USE_UVS)
+    DutUvsBase *dut;
 #elif defined(USE_GSIM)
     DutGSimBase *dut;
 #endif

--- a/template/python/cmake/uvs.cmake
+++ b/template/python/cmake/uvs.cmake
@@ -1,0 +1,104 @@
+add_definitions(-DUSE_UVS)
+
+
+function(search_libs afound rlibs)
+    set(libs_list ${ARGN})
+    set(all_found TRUE)
+    set(libs "")
+    foreach(lib ${libs_list})
+        find_library(LIB_${lib} ${lib})
+        if (NOT LIB_${lib})
+            set(all_found FALSE)
+            break()
+        else()
+            message(STATUS "Found ${lib}: ${LIB_${lib}}")
+            set(libs "${libs} -l${lib}")
+        endif()
+    endforeach()
+    set(${afound} ${all_found} PARENT_SCOPE)
+    set(${rlibs} ${libs} PARENT_SCOPE)
+endfunction()
+
+
+function(XSPyTarget)
+
+	cmake_parse_arguments(
+		XSP
+		""
+		"RTL_MODULE_NAME"
+		"CUSTOM_LIBS;CUSTOM_LINK_OPTIONS"
+		""
+		${ARGN}
+	)
+	add_definitions(-DUSE_UVS)
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftls-model=global-dynamic")
+
+	if (NOT DEFINED XSP_RTL_MODULE_NAME)
+		message(FATAL_ERROR "RTL_MODULE_NAME not defined")
+	endif()
+
+	set(RTLModuleName ${XSP_RTL_MODULE_NAME})
+	set(CustomLibs ${XSP_CUSTOM_LIBS})
+	set(CustomLinkOptions ${XSP_CUSTOM_LINK_OPTIONS})
+
+	# Find UVS
+	if(DEFINED ENV{UVS_HOME})
+		set(UVS_HOME $ENV{UVS_HOME})
+		message(STATUS "Find UVS root: ${UVS_HOME}")
+	else()
+		message(FATAL_ERROR "Cannot find uvs, please install (uvs)")
+	endif()
+
+	# Find UVD
+	if(DEFINED ENV{UVD_HOME})
+		set(UVD_HOME $ENV{UVD_HOME})
+		message(STATUS "Find UVD root: ${UVD_HOME}")
+	else()
+		message(FATAL_ERROR "Cannot find uvd, please install (uvd)")
+	endif()
+
+	# Build the cpp wrapper
+	include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+	add_library(UT${RTLModuleName} SHARED IMPORTED)
+	set_property(
+		TARGET UT${RTLModuleName}
+		PROPERTY IMPORTED_LOCATION
+						 ${CMAKE_CURRENT_SOURCE_DIR}/libUT${RTLModuleName}.so)
+
+	include_directories(${UVS_HOME}/include)
+	execute_process(
+		COMMAND
+			${CMAKE_COMMAND} -E copy
+			${CMAKE_CURRENT_SOURCE_DIR}/libDPI${RTLModuleName}.so
+			${CMAKE_CURRENT_BINARY_DIR}/libDPI${RTLModuleName}.so
+		COMMAND
+			${CMAKE_COMMAND} -E copy_directory
+			${CMAKE_CURRENT_SOURCE_DIR}/libDPI${RTLModuleName}.so.db
+			${CMAKE_CURRENT_BINARY_DIR}/libDPI${RTLModuleName}.so.db)
+
+	add_library(DPI${RTLModuleName} SHARED IMPORTED)
+	set_property(
+		TARGET DPI${RTLModuleName}
+		PROPERTY IMPORTED_LOCATION
+						 ${CMAKE_CURRENT_BINARY_DIR}/libDPI${RTLModuleName}.so)
+
+	# Build the test executable
+	set_property(SOURCE dut.i PROPERTY CPLUSPLUS ON)
+	swig_add_library(UT_${PROJECT_NAME} LANGUAGE python SOURCES dut.i)
+	target_link_libraries(UT_${PROJECT_NAME} PRIVATE UT${RTLModuleName} DPI${RTLModuleName} xspcomm
+	                      ${CustomLibs} ${CMAKE_DL_LIBS} Python3::Module)
+
+	search_libs(ALL_FOUND LIBS zerosoft_rt_stubs m c pthread numa dl)
+	# -Wl,--unresolved-symbols=ignore-in-shared-libs
+	target_link_options(
+		UT_${PROJECT_NAME}
+		PRIVATE
+		-L./		
+		-Wl,-rpath={{__XSPCOMM_LIB__}}
+		-Wl,-rpath=~/.local/lib
+		-Wl,-rpath=/usr/local/lib
+		-Wl,--as-need
+		${LIBS}
+		${CustomLinkOptions})
+
+endfunction()


### PR DESCRIPTION
## Summary
Add **UVS simulator** support to picker (Phase 1), enabling users to generate and build UVS-based testbenches alongside existing Verilator and VCS backends.
## Changes
- **Simulator registration** — Register `uvs` as a supported simulator in the parser map (`src/parser/parser_map.cpp`)
- **Codegen support** — Add UVS-specific include directory flags (`-include`) and waveform dumping support (`$usdbDumpfile` / `$usdbDumpvars`) in the code generator (`src/codegen/lib.cpp`, `src/codegen/sv.cpp`)
- **Build system** — Add three new cmake templates for UVS-based C++, Python, and library builds, handling UVS/UVD detection, DPI library compilation, and linking (`template/cpp/cmake/uvs.cmake`, `template/lib/cmake/uvs.cmake`, `template/python/cmake/uvs.cmake`)
- **DUT runtime** — Add `DutUvsBase` class implementing the UVS simulator interface (clock timing, step/run, finish) and wire it into `DutUnifiedBase` (`template/lib/dut_base.cpp`, `template/lib/dut_base.hpp`)
- **Example integration** — Add reset initialization to example testbenches and a `release-uvs.sh` build script for the DualPortStackCb example
## Notes
- Waveform, checkpoint, restore, and coverage operations are stubbed as unsupported in this phase
- Requires `UVS_HOME` and `UVD_HOME` environment variables at build time
## Stats
12 files changed, 480 insertions(+), 2 deletions(-)