### PR TITLE
fix: disable ASLR when loading VCS simulator library

### DIFF
--- a/template/lib/dut_base.cpp
+++ b/template/lib/dut_base.cpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <functional>
 #include <filesystem>
+#include <sys/personality.h>
 
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
@@ -728,6 +729,17 @@ void DutUnifiedBase::init(int argc, const char **argv)
         memset(this->argv[i], 0, tsize);
         strcpy(this->argv[i], argv[i]);
     }
+
+    // disable ASLR to avoid VCS doing later
+#if defined(USE_VCS)
+    // as described in issue #86, VCS will otherwise try to relaunch the process with ASLR disabled
+    // in newer versions, a malformed argv will cause the relaunch to fail
+    XInfo("Disabling ASLR for better compatibility with VCS");
+    int rc, old_personality = personality(0xffffffff);
+    if (old_personality != -1 && (old_personality & ADDR_NO_RANDOMIZE) == 0)
+        rc = personality(old_personality | ADDR_NO_RANDOMIZE);
+    if (rc == -1 || old_personality == -1) { XWarning("Failed to disable ASLR. If you encounter problems, try to disable ASLR manually."); }
+#endif
 
     // find whether the shared library path is provided
     // share library suffix

--- a/template/lib/dut_base.cpp
+++ b/template/lib/dut_base.cpp
@@ -9,7 +9,9 @@
 #include <map>
 #include <functional>
 #include <filesystem>
+#if defined(USE_VCS) || defined(__linux__)
 #include <sys/personality.h>
+#endif
 
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
@@ -730,15 +732,16 @@ void DutUnifiedBase::init(int argc, const char **argv)
         strcpy(this->argv[i], argv[i]);
     }
 
-    // disable ASLR to avoid VCS doing later
 #if defined(USE_VCS)
+    // disable ASLR to avoid VCS doing later
     // as described in issue #86, VCS will otherwise try to relaunch the process with ASLR disabled
     // in newer versions, a malformed argv will cause the relaunch to fail
     XInfo("Disabling ASLR for better compatibility with VCS");
-    int rc, old_personality = personality(0xffffffff);
+    int rc = 0;
+    int old_personality = personality(0xffffffff);
     if (old_personality != -1 && (old_personality & ADDR_NO_RANDOMIZE) == 0)
         rc = personality(old_personality | ADDR_NO_RANDOMIZE);
-    if (rc == -1 || old_personality == -1) { XWarning("Failed to disable ASLR. If you encounter problems, try to disable ASLR manually."); }
+    if (old_personality == -1 || rc == -1) { XWarning("Failed to disable ASLR. If you encounter problems, try to disable ASLR manually."); }
 #endif
 
     // find whether the shared library path is provided


### PR DESCRIPTION
# Description

As described in #86, VCS will launch a new instance of python after disabling ASLR. Because the argv to that `execv` call is malformed, this interrupts the original process and drops the user in a clean shell.
To avoid this, we disable ASLR before VCS initializes and thus prevent the undesired behavior.

Fixes #86


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with VCS 2025 on Rocky 9.5 while using `LD_PRELOAD`.