### PR TITLE
fix(ci): validate Docker image build on PR Docker changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,48 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  docker-pr-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    if: github.event_name == 'pull_request'
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect Docker-related changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docker:
+              - 'Dockerfile'
+              - '.build-config.yml'
+
+  docker-build-validate:
+    needs: docker-pr-changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request' && needs.docker-pr-changes.outputs.docker == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image for validation
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: false
+
   docker-build-push:
     needs: build-and-test
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN VERILATOR_VERSION="$(sed -n 's/^  verilator:[[:space:]]*//p' /tmp/build-conf
     ./configure --prefix=/usr/local && \
     make -j"$(nproc)" && \
     make install && \
-    rm -rf /tmp/verilator /tmp/build-config.yml
+    rm -rf /tmp/verilator
 
 # Verify toolchain
 RUN swig -version && cmake --version && verilator --version && java --version && python3 --version
@@ -105,7 +105,8 @@ RUN mkdir -p $NVM_DIR && \
     ln -sf "$NVM_DIR/versions/node/v${NODE_VERSION}/bin/npx" /usr/local/bin/npx && \
     chmod -R 777 $NVM_DIR && \
     echo 'export NVM_DIR="/usr/local/nvm"' >> /etc/bash.bashrc && \
-    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/bash.bashrc
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/bash.bashrc && \
+    rm -f /tmp/build-config.yml
 
 ENV PATH=$NVM_DIR/versions/node/current/bin:$PATH
 


### PR DESCRIPTION
# Description

Run a Docker build validation job on pull requests when Dockerfile or .build-config.yml changes, without pushing the image.

Also keep /tmp/build-config.yml until the Node installation step finishes so the Docker build can still resolve the configured Node version after the Verilator step.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
