### PR TITLE
Support header entries in RTL filelists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := all
 
 .PHONY: all init build install appimage test test_all test_vpi_all test_mem_direct_all \
         test_all_java test_all_scala clean wheel wheel_install tests smoke_tests unit_tests

--- a/example/MultiFileRTL/design.f
+++ b/example/MultiFileRTL/design.f
@@ -1,0 +1,5 @@
++incdir+inc
+inc/defs.vh
+inc/outer.svh
+leaf.v
+top.sv

--- a/example/MultiFileRTL/example.py
+++ b/example/MultiFileRTL/example.py
@@ -1,0 +1,29 @@
+try:
+    from UT_MultiFileRTLTop import *
+except:
+    try:
+        from MultiFileRTLTop import *
+    except:
+        from __init__ import *
+
+
+if __name__ == "__main__":
+    dut = DUTMultiFileRTLTop()
+
+    test_vectors = [
+        0x0,
+        0x1,
+        0x5A,
+        0x123,
+        0xABC,
+        0xFFF,
+    ]
+
+    for idx, value in enumerate(test_vectors):
+        dut.a.value = value
+        dut.Step(1)
+        print(f"case {idx}: a=0x{value:x}, b=0x{dut.b.value:x}")
+        assert dut.b.value == value, "output mismatch"
+
+    print("Test Passed, destroy UTMultiFileRTLTop")
+    dut.Finish()

--- a/example/MultiFileRTL/inc/defs.vh
+++ b/example/MultiFileRTL/inc/defs.vh
@@ -1,0 +1,1 @@
+`define MULTI_FILE_RTL_W 8

--- a/example/MultiFileRTL/inc/outer.svh
+++ b/example/MultiFileRTL/inc/outer.svh
@@ -1,0 +1,2 @@
+`include "defs.vh"
+`define MULTI_FILE_RTL_OUT_W (`MULTI_FILE_RTL_W + 4)

--- a/example/MultiFileRTL/leaf.v
+++ b/example/MultiFileRTL/leaf.v
@@ -1,0 +1,8 @@
+module MultiFileRTLLeaf #(
+    parameter WIDTH = 8
+) (
+    input  [WIDTH-1:0] a,
+    output [WIDTH-1:0] b
+);
+    assign b = a;
+endmodule

--- a/example/MultiFileRTL/release-vcs.sh
+++ b/example/MultiFileRTL/release-vcs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+OUT_ROOT="${OUT_ROOT:-output}"
+OUT_DIR="$(realpath -m "${OUT_ROOT}/MultiFileRTL")"
+LANGUAGE_ARGS=()
+
+rm -rf "$OUT_DIR"
+if [[ $* == *"python"* ]]; then
+    LANGUAGE_ARGS+=(--lang python)
+fi
+
+./build/bin/picker export \
+  --fs example/MultiFileRTL/design.f \
+  --autobuild true \
+  --sim vcs \
+  --verdi-mode modern \
+  -w MultiFileRTLTop.fsdb \
+  --sname MultiFileRTLTop \
+  --tdir "$OUT_DIR" \
+  --sdir template \
+  "${LANGUAGE_ARGS[@]}" \
+  "$@"
+
+if [[ $* == *"python"* ]]; then
+    cp example/MultiFileRTL/example.py "$OUT_DIR"
+    cd "$OUT_DIR"
+    python3 example.py
+fi

--- a/example/MultiFileRTL/top.sv
+++ b/example/MultiFileRTL/top.sv
@@ -1,0 +1,13 @@
+`include "outer.svh"
+
+module MultiFileRTLTop(
+    input logic [`MULTI_FILE_RTL_OUT_W-1:0] a,
+    output logic [`MULTI_FILE_RTL_OUT_W-1:0] b
+);
+    MultiFileRTLLeaf #(
+        .WIDTH(`MULTI_FILE_RTL_OUT_W)
+    ) u_leaf (
+        .a(a),
+        .b(b)
+    );
+endmodule

--- a/src/codegen/lib.cpp
+++ b/src/codegen/lib.cpp
@@ -43,7 +43,9 @@ namespace picker { namespace codegen {
                       std::string &ofilelist, std::vector<std::string> &incdirs)
     {
         std::vector<std::pair<std::string, std::string>> path_list;
-        const std::vector<std::string> allow_file_types = {".sv", ".v", ".cpp", ".c", ".cc", ".cxx", ".so", ".a", ".o"};
+        const std::vector<std::string> allow_file_types = {
+            ".sv", ".v", ".svh", ".vh", ".cpp", ".c", ".cc", ".cxx", ".so", ".a", ".o"};
+        const std::vector<std::string> header_file_types = {".svh", ".vh"};
         std::unordered_set<std::string> incdir_set;
         auto resolve_input_path = [](const std::string &path, const std::string &base_dir) {
             auto resolved = std::filesystem::path(path);
@@ -129,6 +131,10 @@ namespace picker { namespace codegen {
                 if (!std::filesystem::exists(resolved_file)) PK_FATAL("File not found: %s\n", target_file.c_str());
                 path = std::filesystem::absolute(resolved_file).lexically_normal().string();
                 if (source_file_set.count(path) != 0) { continue; } // skip source file
+                if (check_file_type(path, header_file_types)) {
+                    add_incdir(std::filesystem::path(path).parent_path().string(), "");
+                    continue;
+                }
                 ofilelist += path + "\n";
             } else if (path.ends_with("/")) { // directory
                 auto target_dir = path;
@@ -138,7 +144,14 @@ namespace picker { namespace codegen {
                 for (const auto &entry : iter) {
                     if (entry.is_regular_file()) {
                         std::string filename = entry.path().filename().string();
-                        if (check_file_type(filename, allow_file_types)) { ofilelist += entry.path().string() + "\n"; }
+                        if (check_file_type(filename, allow_file_types)) {
+                            const auto entry_path = entry.path().string();
+                            if (check_file_type(entry_path, header_file_types)) {
+                                add_incdir(entry.path().parent_path().string(), "");
+                                continue;
+                            }
+                            ofilelist += entry_path + "\n";
+                        }
                     }
                 }
             } else {

--- a/test/test_codegen_filelist.cpp
+++ b/test/test_codegen_filelist.cpp
@@ -68,6 +68,8 @@ int main()
     fs::create_directories(cwd_base / "inc_shadow");
 
     write_text(base / "rtl1.sv", "module m; endmodule\n");
+    write_text(base / "defs.vh", "`define DEF_W 8\n");
+    write_text(base / "macro.svh", "`include \"defs.vh\"\n");
     write_text(base / "sub" / "rtl2.v", "module n; endmodule\n");
     write_text(base / "sub2" / "ignore.txt", "noop\n");
     write_text(base / "sub2" / "rtl3.sv", "module p; endmodule\n");
@@ -153,6 +155,26 @@ int main()
     assert(incdirs3.front() == base.string());
     assert(contains_line(ofilelist3, (base / "rtl1.sv").string()));
     assert(!contains_line(ofilelist3, (cwd_base / "rtl1.sv").string()));
+
+    const fs::path filelist4 = base / "filelist4.f";
+    write_text(filelist4,
+               "defs.vh\n"
+               "macro.svh\n"
+               "rtl1.sv\n");
+
+    std::string ofilelist4;
+    std::vector<std::string> incdirs4;
+    stderr_output = capture_stderr([&]() {
+        picker::codegen::gen_filelist({}, {filelist4.string()}, ofilelist4, incdirs4);
+    });
+
+    assert(stderr_output.empty());
+    assert(contains_line(ofilelist4, (base / "rtl1.sv").string()));
+    assert(!contains_line(ofilelist4, (base / "defs.vh").string()));
+    assert(!contains_line(ofilelist4, (base / "macro.svh").string()));
+    std::set<std::string> incset4(incdirs4.begin(), incdirs4.end());
+    assert(incset4.size() == 1);
+    assert(incset4.count(base.string()) == 1);
 
     fs::remove_all(cwd_base);
     fs::remove_all(base);


### PR DESCRIPTION
# Description

This PR improves export filelist handling for header-only RTL entries and makes the top-level build more stable in CI.

Changes included:

- support `.vh` and `.svh` entries in RTL filelists during `picker export`
- treat header entries as include directories instead of simulator source files
- keep generated simulator `filelist.f` limited to compilable RTL sources such as `.v` and `.sv`
- set the top-level `Makefile` default goal explicitly to `all` so plain `make` does not accidentally select example targets in CI or container builds
- add regression coverage for header-only filelist entries

This is a non-breaking change intended to make multi-file RTL filelists behave more like common HDL project layouts.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added a unit test case covering `.vh` / `.svh` entries in filelists
- [x] Verified generated simulator filelists keep `.v` / `.sv` entries and exclude header-only entries
- [x] Reviewed top-level `make` behavior to ensure the default goal is explicitly `all`

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A
* Toolchain: local GCC / CMake build environment
* SDK: N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules