### PR TITLE
fix: filelist and build threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Options:
   --verbose                   Verbose mode
   -e,--example                Build example project, default is OFF
   --autobuild BOOLEAN [1]     Auto build the generated project, default is true
+  -j,--build-threads INT [0]  Maximum parallel build threads; 0 uses all available CPU cores
 ```
 
 Static Multi-Module Support:

--- a/README.zh.md
+++ b/README.zh.md
@@ -181,6 +181,7 @@ Options:
   --verbose                   Verbose mode
   -e,--example                Build example project, default is OFF
   --autobuild BOOLEAN [1]     Auto build the generated project, default is true
+  -j,--build-threads INT [0]  最大并行构建线程数；0 表示使用所有可用 CPU 核心
 ```
 
 pack 子命令用于将 UVM 中的 sequence_item 转换为其他语言，然后通过 TLM 进行通信（目前支持 Python，其他语言在开发中）
@@ -227,6 +228,7 @@ Options:
 - `--verbose`: 可选。详细模式
 - `-e,--example`: 可选。构建示例项目，默认是 OFF
 - `--autobuild BOOLEAN [1]`: 可选。自动构建生成的项目，默认是 true
+- `-j,--build-threads INT [0]`: 可选。限制生成项目的最大并行构建线程数，0 表示使用所有可用 CPU 核心
 
 静态多模块支持：
 

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -43,6 +43,7 @@ typedef struct export_opts {
     bool verbose;
     bool example;
     bool autobuild;
+    int build_threads;
     bool cp_lib;
     SignalAccessType rw_type;
     std::vector<std::string> transaction;

--- a/src/codegen/lib.cpp
+++ b/src/codegen/lib.cpp
@@ -359,6 +359,9 @@ namespace picker { namespace codegen {
         data["__VERDI_MODE__"]            = opts.verdi_mode;
         data["__RW_TYPE__"]               = opts.rw_type == picker::SignalAccessType::MEM_DIRECT ? "MEM_DIRECT" : "DPI";
         data["__TARGET_LANGUAGE__"]       = opts.language;
+        data["__BUILD_THREADS__"] =
+            opts.build_threads > 0 ? std::to_string(opts.build_threads) :
+                                     "$(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)";
         data["__FILELIST__"]              = ofilelist;
         data["__LIB_DPI_FUNC_NAME_HASH__"] = std::string(lib_random_hash);
         data["__GENERATOR_PICKER_PATH__"] =

--- a/src/parser/sv.cpp
+++ b/src/parser/sv.cpp
@@ -266,7 +266,8 @@ namespace picker { namespace parser {
         {
             driver.addStandardArgs();
 
-            std::vector<std::string> args = {"picker-slang", "--single-unit", "--ignore-unknown-modules"};
+            std::vector<std::string> args = {"picker-slang", "--single-unit", "--ignore-unknown-modules",
+                                             "--exclude-ext", "so,a,o"};
             if (opts.sim == "vcs") {
                 args.push_back("--compat");
                 args.push_back("vcs");

--- a/src/picker.cpp
+++ b/src/picker.cpp
@@ -161,6 +161,10 @@ int set_options_export_rtl(CLI::App &top_app)
     app->add_flag("-e,--example", export_opts.example, "Build example project, default is OFF");
     app->add_option("--autobuild", export_opts.autobuild, "Auto build the generated project, default is true")
         ->default_val(true);
+    app->add_option("-j,--build-threads", export_opts.build_threads,
+                    "Maximum parallel build threads; 0 uses all available CPU cores")
+        ->default_val(0)
+        ->check(CLI::NonNegativeNumber);
 
     return 0;
 }

--- a/template/cpp/Makefile
+++ b/template/cpp/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR := $(shell pwd)
-NPROC := $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
+NPROC ?= $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
 .PHONY: all test compile clean purge copy_xspcomm
 
 all: test clean

--- a/template/golang/Makefile
+++ b/template/golang/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR := $(shell pwd)
-NPROC := $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
+NPROC ?= $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
 .PHONY: all test compile clean purge copy_xspcomm
 
 all: test clean

--- a/template/java/Makefile
+++ b/template/java/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR := $(shell pwd)
-NPROC := $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
+NPROC ?= $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
 .PHONY: all test compile clean purge copy_xspcomm
 
 all: test clean

--- a/template/lib/Makefile
+++ b/template/lib/Makefile
@@ -13,7 +13,7 @@ export COVERAGE := {{__COVERAGE__}}
 export CHECKPOINTS := {{__CHECKPOINTS__}}
 export VPI := {{__VPI__}}
 export RW_TYPE := {{__RW_TYPE__}}
-NPROC := $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
+export NPROC := {{__BUILD_THREADS__}}
 
 ifeq ($(SIMULATOR), verilator)
 MEM_DIRECT_TARGET_FILE := build/DPI{{__TOP_MODULE_NAME__}}/V{{__TOP_MODULE_NAME__}}___024root.h

--- a/template/lua/Makefile
+++ b/template/lua/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR := $(shell pwd)
-NPROC := $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
+NPROC ?= $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
 .PHONY: all test compile clean purge copy_xspcomm
 
 all: test clean

--- a/template/python/Makefile
+++ b/template/python/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR := $(shell pwd)
-NPROC := $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
+NPROC ?= $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
 .PHONY: all test compile clean purge copy_xspcomm
 
 all: test clean

--- a/template/scala/Makefile
+++ b/template/scala/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR := $(shell pwd)
-NPROC := $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
+NPROC ?= $(shell (nproc 2>/dev/null || sysctl -n hw.ncpu) 2>/dev/null)
 .PHONY: all test compile clean purge copy_xspcomm
 
 all: test clean

--- a/test/scripts/test_export_filelist.sh
+++ b/test/scripts/test_export_filelist.sh
@@ -38,6 +38,7 @@ OUT_DIR="${TMP_DIR}/out/FileListTop"
 blue "[export-filelist] Exporting from a filelist with a minimal tool PATH"
 env PATH="/usr/bin:/bin" "${PICKER_BIN}" export \
   --autobuild false \
+  --build-threads 3 \
   --sdir "${ROOT_DIR}/template" \
   --sname FileListTop \
   --fs "${TMP_DIR}/list/design.f" \
@@ -48,5 +49,7 @@ env PATH="/usr/bin:/bin" "${PICKER_BIN}" export \
 test -d "${OUT_DIR}"
 test -f "${OUT_DIR}/CMakeLists.txt"
 test -d "${OUT_DIR}/python"
+grep -Fxq 'export NPROC := 3' "${OUT_DIR}/Makefile"
+grep -Fq 'NPROC ?=' "${OUT_DIR}/python/Makefile"
 
 green "[export-filelist] OK"

--- a/test/test_codegen_filelist.cpp
+++ b/test/test_codegen_filelist.cpp
@@ -73,6 +73,9 @@ int main()
     write_text(base / "sub" / "rtl2.v", "module n; endmodule\n");
     write_text(base / "sub2" / "ignore.txt", "noop\n");
     write_text(base / "sub2" / "rtl3.sv", "module p; endmodule\n");
+    write_text(base / "dependency.so", "shared library placeholder\n");
+    write_text(base / "dependency.a", "archive placeholder\n");
+    write_text(base / "dependency.o", "object placeholder\n");
     write_text(cwd_base / "rtl1.sv", "module wrong; endmodule\n");
 
     const fs::path filelist = base / "filelist.f";
@@ -160,7 +163,10 @@ int main()
     write_text(filelist4,
                "defs.vh\n"
                "macro.svh\n"
-               "rtl1.sv\n");
+               "rtl1.sv\n"
+               "dependency.so\n"
+               "dependency.a\n"
+               "dependency.o\n");
 
     std::string ofilelist4;
     std::vector<std::string> incdirs4;
@@ -172,6 +178,9 @@ int main()
     assert(contains_line(ofilelist4, (base / "rtl1.sv").string()));
     assert(!contains_line(ofilelist4, (base / "defs.vh").string()));
     assert(!contains_line(ofilelist4, (base / "macro.svh").string()));
+    assert(contains_line(ofilelist4, (base / "dependency.so").string()));
+    assert(contains_line(ofilelist4, (base / "dependency.a").string()));
+    assert(contains_line(ofilelist4, (base / "dependency.o").string()));
     std::set<std::string> incset4(incdirs4.begin(), incdirs4.end());
     assert(incset4.size() == 1);
     assert(incset4.count(base.string()) == 1);

--- a/test/test_parser_sv_unit.cpp
+++ b/test/test_parser_sv_unit.cpp
@@ -229,6 +229,40 @@ namespace {
         fs::remove_all(base);
     }
 
+    void test_filelist_ignores_linker_inputs()
+    {
+        namespace fs = std::filesystem;
+        const fs::path base = fs::temp_directory_path() / "picker_test_sv_filelist_linker_inputs";
+        fs::remove_all(base);
+        fs::create_directories(base);
+
+        write_text(base / "linker_top.sv",
+                   "module LinkerTop(input logic clk);\n"
+                   "endmodule\n");
+        write_text(base / "dependency.so", "not SystemVerilog\n");
+        write_text(base / "dependency.a", "not SystemVerilog\n");
+        write_text(base / "dependency.o", "not SystemVerilog\n");
+        write_text(base / "filelist.f",
+                   "linker_top.sv\n"
+                   "dependency.so\n"
+                   "dependency.a\n"
+                   "dependency.o\n");
+
+        picker::export_opts opts {};
+        opts.filelists = {(base / "filelist.f").string()};
+        opts.source_module_name_list = {"LinkerTop"};
+
+        std::vector<picker::sv_module_define> modules;
+        picker::parser::sv(opts, modules);
+
+        assert(modules.size() == 1);
+        assert(modules.front().module_name == "LinkerTop");
+        assert(modules.front().pins.size() == 1);
+        assert(modules.front().pins.front().logic_pin == "clk");
+
+        fs::remove_all(base);
+    }
+
     void test_missing_child_modules_do_not_block_top_port_extraction()
     {
         namespace fs = std::filesystem;
@@ -273,6 +307,7 @@ int main()
     test_filelist_macro_defines_are_shared_across_sources();
     test_filelist_dependencies_are_used_without_explicit_module_name();
     test_filelist_order_wins_when_explicit_file_is_duplicate();
+    test_filelist_ignores_linker_inputs();
     test_missing_child_modules_do_not_block_top_port_extraction();
     return 0;
 }


### PR DESCRIPTION
# Description

  This PR fixes RTL filelist handling and adds control over generated-project build parallelism.

  The RTL parser now excludes `.so`, `.a`, and `.o` linker inputs before passing filelists to slang. These files
  remain in the generated simulator filelist, so they are still available to Verilator, VCS, and UVS during
  compilation and linking.

  This PR also adds the `-j,--build-threads` export option:

  - A positive value limits the parallelism used when building generated projects.
  - The configured value is propagated to DUT and language-wrapper Makefiles.
  - A value of `0`, which is the default, continues to use all available CPU cores.
  - Users can still override the generated value with `make NPROC=<value>`.

  No additional dependencies are required.

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

  # How Has This Been Tested?

  The following checks were performed:

  - [x] Built Picker with 16 parallel build jobs:
    `cmake --build build --target picker -j16`
  - [x] Ran the slang RTL parser unit test:
    `ctest --test-dir build -R '^test_parser_sv_unit$' --output-on-failure`
  - [x] Ran the export filelist integration test:
    `bash test/scripts/test_export_filelist.sh`
  - [x] Verified that `--build-threads 3` renders `export NPROC := 3`.
  - [x] Verified that the default value renders automatic CPU detection.
  - [x] Verified that negative build-thread values are rejected.
  - [x] Added coverage confirming `.so`, `.a`, and `.o` are ignored by slang but retained in generated simulator
  filelists.

  `test_codegen_filelist` encounters an existing path-string assertion on this environment because `/tmp/
  picker_test_filelist/` and `/tmp/picker_test_filelist` differ only by a trailing slash. This occurs before the
  newly added linker-input assertions and is unrelated to this change.

  **Test Configuration**:

  * Firmware version: N/A
  * Hardware: x86_64
  * Toolchain: C++20, CMake/Ninja, slang v11
  * SDK: N/A

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have added the appropriate labels
  - [x] I have performed a self-review of my code
  - [x] I have commented my code where additional explanation is required
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes