### PR TITLE
fix(codegen): encode dollar-sign DPI identifiers

### DIFF
--- a/include/picker.hpp
+++ b/include/picker.hpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <regex>
 #include <set>
+#include <string_view>
 #include <unistd.h>
 #include <filesystem>
 #include <functional>
@@ -245,6 +246,34 @@ inline std::string str_replace_all(std::string str, const std::string &from, con
         start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
     }
     return str;
+}
+
+// Return the base name used by generated DPI-C symbols. Keep the historical
+// dot-to-underscore spelling for ordinary signals. A dollar sign is legal in
+// a SystemVerilog identifier but not in a C identifier, so encode the complete
+// logical name behind a reserved prefix in that case. The prefix deliberately
+// contains no underscore, so Picker's underscore-delimited signal tree keeps
+// the encoded name as one leaf. Names already using the prefix in any letter
+// case are encoded as well: Go capitalizes generated fields, so reserving only
+// the lowercase spelling would allow a host-member collision. This keeps the
+// extension collision-free without changing other existing names.
+inline std::string dpi_function_base_name(const std::string &logic_pin)
+{
+    static constexpr std::string_view encoded_prefix = "pickerdpix";
+    static constexpr char hex[]                       = "0123456789abcdef";
+
+    std::string flattened = str_replace_all(logic_pin, ".", "_");
+    const bool needs_encoding = flattened.find('$') != std::string::npos
+                                || lower_case(flattened).starts_with(encoded_prefix);
+    if (!needs_encoding) { return flattened; }
+
+    std::string encoded(encoded_prefix);
+    encoded.reserve(encoded.size() + logic_pin.size() * 2);
+    for (unsigned char c : logic_pin) {
+        encoded.push_back(hex[c >> 4]);
+        encoded.push_back(hex[c & 0x0f]);
+    }
+    return encoded;
 }
 
 template <typename T>

--- a/src/codegen/cpp.cpp
+++ b/src/codegen/cpp.cpp
@@ -53,7 +53,7 @@ namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = pin[i].logic_pin_type;
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 // Set 0 for 1bit singal or hb-lb+1 for vector signal for cpp
@@ -97,7 +97,7 @@ namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = pin[i].logic_pin_type;
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 // Set empty or [hb:lb] for verilog render

--- a/src/codegen/golang.cpp
+++ b/src/codegen/golang.cpp
@@ -32,7 +32,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = (pin[i].logic_pin_type[0] == 'i') ? "IOType_Input" : "IOType_Output";
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, true);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector
@@ -64,7 +64,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = pin[i].logic_pin_type;
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, true);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector

--- a/src/codegen/java.cpp
+++ b/src/codegen/java.cpp
@@ -33,7 +33,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = (pin[i].logic_pin_type[0] == 'i') ? "In" : "Out";
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector
@@ -65,7 +65,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = pin[i].logic_pin_type;
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector

--- a/src/codegen/lua.cpp
+++ b/src/codegen/lua.cpp
@@ -29,7 +29,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = (pin[i].logic_pin_type[0] == 'i') ? "In" : "Out";
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector
@@ -58,7 +58,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = pin[i].logic_pin_type;
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector

--- a/src/codegen/python.cpp
+++ b/src/codegen/python.cpp
@@ -31,9 +31,8 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = (pin[i].logic_pin_type[0] == 'i') ? "In" : "Out";
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
-                auto pin_uniq_name = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
-                data["pin_uniq_name"]  = str_replace_all(str_replace_all(pin_uniq_name, "$$", "_"), "$", "_");
+                data["pin_func_name"] = picker::dpi_function_base_name(pin[i].logic_pin);
+                data["pin_uniq_name"] = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector
                                                0 :
@@ -68,7 +67,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = pin[i].logic_pin_type;
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector

--- a/src/codegen/scala.cpp
+++ b/src/codegen/scala.cpp
@@ -31,7 +31,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = (pin[i].logic_pin_type[0] == 'i') ? "In" : "Out";
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector
@@ -62,7 +62,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]      = pin[i].logic_pin;
                 data["logic_pin_type"] = pin[i].logic_pin_type;
-                data["pin_func_name"]  = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]  = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["pin_uniq_name"]  = picker::fix_conflict_pin_name(data["pin_func_name"], pin_map, false);
 
                 data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ? // means not vector

--- a/src/codegen/sv.cpp
+++ b/src/codegen/sv.cpp
@@ -112,7 +112,7 @@ namespace picker { namespace codegen {
                         data["raw_pin"]                    = pin[i].logic_pin;
                         data["logic_pin"]                  = temp_pin.logic_pin;
                         data["logic_pin_type"]             = pin[i].logic_pin_type;
-                        data["pin_func_name"]              = str_replace_all(temp_pin.logic_pin, ".", "_");
+                        data["pin_func_name"]              = picker::dpi_function_base_name(temp_pin.logic_pin);
                         data["__LIB_DPI_FUNC_NAME_HASH__"] = std::string(lib_random_hash);
                         // Set empty or [hb:lb] for verilog render
                         data["logic_pin_length"] = pin[i].logic_pin_hb == -1 ?
@@ -156,7 +156,7 @@ namespace picker { namespace codegen {
             for (int i = 0; i < pin.size(); i++) {
                 data["logic_pin"]                  = pin[i].logic_pin;
                 data["logic_pin_type"]             = pin[i].logic_pin_type;
-                data["pin_func_name"]              = str_replace_all(pin[i].logic_pin, ".", "_");
+                data["pin_func_name"]              = picker::dpi_function_base_name(pin[i].logic_pin);
                 data["__LIB_DPI_FUNC_NAME_HASH__"] = std::string(lib_random_hash);
 
                 // Set empty or [hb:lb] for verilog render
@@ -273,7 +273,7 @@ namespace picker { namespace codegen {
             // Build the TRIE
             TrieNode *root = new TrieNode();
             for (auto signal : signal_list) {
-                std::vector<std::string> signal_split = split(str_replace_all(signal.logic_pin, ".", "_"), '_');
+                std::vector<std::string> signal_split = split(picker::dpi_function_base_name(signal.logic_pin), '_');
                 TrieNode *current                     = root;
                 for (auto part_name : signal_split) {
                     if (current->children.find(part_name) == current->children.end()) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,6 +59,11 @@ pack_python: preflight
 export_java: preflight
 	bash "$(SCRIPT_DIR)/test_export_adder_java.sh"
 
+.PHONY: export_internal_dollar_python
+all: export_internal_dollar_python
+export_internal_dollar_python: preflight
+	bash "$(SCRIPT_DIR)/test_export_internal_dollar_python.sh"
+
 sv_build: preflight
 	bash "$(SCRIPT_DIR)/test_sv_verilator_build.sh"
 

--- a/test/data/internal_dollar.py
+++ b/test/data/internal_dollar.py
@@ -1,0 +1,19 @@
+try:
+    from UT_dpi_dollar import *
+except ImportError:
+    from dpi_dollar import *
+
+
+if __name__ == "__main__":
+    dut = DUTdpi_dollar()
+    try:
+        input_signal = dut.pickerdpix696e2431
+        output_signal = dut.pickerdpix6f75742431
+        internal_signal = dut.pickerdpix6470695f646f6c6c61722e7369672431
+        input_signal.value = 1
+        dut.Step(1)
+        assert output_signal.value == 1
+        assert internal_signal.value == 1
+    finally:
+        dut.Finish()
+    print("DPI_INTERNAL_DOLLAR_OK")

--- a/test/data/internal_dollar.sv
+++ b/test/data/internal_dollar.sv
@@ -1,0 +1,14 @@
+module dpi_dollar(
+  input logic clock,
+  input logic reset,
+  input logic in$1,
+  output logic out$1
+);
+  logic sig$1;
+
+  assign out$1 = in$1;
+
+  initial begin
+    sig$1 = 1'b1;
+  end
+endmodule

--- a/test/data/internal_dollar.yaml
+++ b/test/data/internal_dollar.yaml
@@ -1,0 +1,2 @@
+dpi_dollar:
+  - "logic sig$1"

--- a/test/scripts/test_export_internal_dollar_python.sh
+++ b/test/scripts/test_export_internal_dollar_python.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+require_cmd cmake
+require_cmd grep
+require_cmd python3
+require_cmd tee
+
+PICKER_BIN="$(resolve_picker)"
+ROOT_DIR="${ROOT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+OUTPUT_DIR="${ROOT_DIR}/picker_out_internal_dollar"
+PROJECT_DIR="${OUTPUT_DIR}/dpi_dollar"
+BUILD_LOG="${OUTPUT_DIR}/build.log"
+
+blue "[export-internal-dollar-python] Exporting a DPI signal whose SV name contains '$'"
+rm -rf "${OUTPUT_DIR}"
+"${PICKER_BIN}" export \
+  "${ROOT_DIR}/test/data/internal_dollar.sv" \
+  --autobuild false \
+  --sdir "${ROOT_DIR}/template" \
+  --sname dpi_dollar \
+  --tdir "${PROJECT_DIR}" \
+  --lang python \
+  --sim verilator \
+  --internal "${ROOT_DIR}/test/data/internal_dollar.yaml"
+
+DPI_C_SYMBOL="$(python3 - "${PROJECT_DIR}/dpi_dollar_top.sv" <<'PY'
+import re
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+pattern = (
+    r'export "DPI-C" function '
+    r'(get_pickerdpix6470695f646f6c6c61722e7369672431xx[A-Za-z0-9_]+);'
+)
+matches = re.findall(pattern, source)
+if len(matches) != 1:
+    raise SystemExit(f"expected one collision-safe dollar-sign DPI symbol, found {len(matches)}")
+print(matches[0])
+PY
+)"
+
+cp "${ROOT_DIR}/test/data/internal_dollar.py" "${PROJECT_DIR}/python/example.py"
+
+blue "[export-internal-dollar-python] Building and reading the generated internal signal"
+set +e
+make -C "${PROJECT_DIR}" EXAMPLE=ON -j"$(nproc)" 2>&1 | tee "${BUILD_LOG}"
+make_status=${PIPESTATUS[0]}
+set -e
+
+if [[ ${make_status} -ne 0 ]]; then
+  red "[export-internal-dollar-python] Generated project build failed"
+  exit "${make_status}"
+fi
+if ! grep -Fq "DPI_INTERNAL_DOLLAR_OK" "${BUILD_LOG}"; then
+  red "[export-internal-dollar-python] Generated DUT did not read the dollar-sign signal"
+  exit 1
+fi
+
+DPI_LIB="$(find "${PROJECT_DIR}" -maxdepth 1 -type f -name 'libUTdpi_dollar.*' -print -quit)"
+if [[ -z "${DPI_LIB}" ]]; then
+  red "[export-internal-dollar-python] Generated DUT library was not found"
+  exit 1
+fi
+
+python3 - "${DPI_LIB}" "${DPI_C_SYMBOL}" <<'PY'
+import ctypes
+import sys
+
+library_path, symbol = sys.argv[1:]
+library = ctypes.CDLL(library_path)
+try:
+    getattr(library, symbol)
+except AttributeError as exc:
+    raise SystemExit(f"generated DPI-C symbol is missing from final library: {symbol}") from exc
+print(f"DPI_INTERNAL_DOLLAR_SYMBOL={symbol}")
+PY
+
+green "[export-internal-dollar-python] OK"

--- a/test/test_codegen_sv_param.cpp
+++ b/test/test_codegen_sv_param.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,13 @@ int main()
     std::vector<picker::sv_module_define> modules{mod};
     std::vector<picker::sv_signal_define> internal{
         {"sig0", "output", 7, 0},
+        {"sig$1", "output", -1, 0},
+        {"a.b$", "output", -1, 0},
+        {"a_b$", "output", -1, 0},
+        {"a$", "output", -1, 0},
+        {"b$", "output", -1, 0},
+        {"Picker_dpi.foo", "output", -1, 0},
+        {"Picker_dpi.bar", "output", -1, 0},
     };
 
     nlohmann::json signal_tree;
@@ -49,6 +57,13 @@ int main()
     assert(contains_line(dpi_export, "get_a"));
     assert(contains_line(dpi_export, "set_a"));
     assert(contains_line(dpi_export, "get_sig0"));
+    assert(contains_line(dpi_export, "function get_pickerdpix7369672431xxH;"));
+    assert(contains_line(dpi_export, "function get_pickerdpix612e6224xxH;"));
+    assert(contains_line(dpi_export, "function get_pickerdpix615f6224xxH;"));
+    const auto dpi_impl = data["__DPI_FUNCTION_IMPLEMENT__"].get<std::string>();
+    assert(contains_line(dpi_impl, "function void get_pickerdpix7369672431xxH;"));
+    assert(contains_line(dpi_impl, "function void get_pickerdpix612e6224xxH;"));
+    assert(contains_line(dpi_impl, "function void get_pickerdpix615f6224xxH;"));
 
     const auto sv_wave = data["__SV_DUMP_WAVE__"].get<std::string>();
     assert(contains_line(sv_wave, "wave.vcd"));
@@ -56,6 +71,18 @@ int main()
     const auto tree = data["__SIGNAL_TREE__"].get<std::string>();
     assert(contains_line(tree, "a"));
     assert(contains_line(tree, "b"));
+    assert(signal_tree.contains("pickerdpix6124"));
+    assert(signal_tree.contains("pickerdpix6224"));
+
+    // Encoded names stay leaf tokens rather than creating a shared
+    // underscore-delimited hierarchy. Go capitalizes cascaded XPort members,
+    // so every non-leaf root must remain unique after that normalization.
+    std::set<std::string> go_cascaded_roots;
+    for (const auto &[key, port] : signal_tree.items()) {
+        if (!port.contains("_")) {
+            assert(go_cascaded_roots.insert(picker::capitalize_first_letter(key)).second);
+        }
+    }
 
     // MEM_DIRECT adds public_flat markers
     nlohmann::json data2;

--- a/test/test_picker_utils.cpp
+++ b/test/test_picker_utils.cpp
@@ -46,6 +46,22 @@ int main() {
   assert(picker::streplace(string("a_b_c"), string("_"), string("-")) == string("a-b-c"));
   assert(picker::streplace(string("a_b_c"), {"a_", "_c"}, string("")) == string("b"));
 
+  // DPI-C names preserve the historical spelling unless a SystemVerilog-only
+  // dollar sign or the reserved encoding prefix requires reversible encoding.
+  assert(picker::dpi_function_base_name("dut.signal") == string("dut_signal"));
+  assert(picker::dpi_function_base_name("dut.sig$1") == string("pickerdpix6475742e7369672431"));
+  assert(picker::dpi_function_base_name("pickerdpix24") ==
+         string("pickerdpix7069636b6572647069783234"));
+  assert(picker::dpi_function_base_name("Pickerdpix6124") ==
+         string("pickerdpix5069636b65726470697836313234"));
+  assert(picker::dpi_function_base_name("dut.sig$1") !=
+         picker::dpi_function_base_name("pickerdpix6475742e7369672431"));
+  assert(picker::dpi_function_base_name("a$").find('_') == string::npos);
+  // Go capitalizes generated members, so the encoded spelling for `a$` must
+  // remain distinct from a user signal that already has that capitalized form.
+  assert(picker::capitalize_first_letter(picker::dpi_function_base_name("a$")) !=
+         picker::capitalize_first_letter(picker::dpi_function_base_name("Pickerdpix6124")));
+
   // contains helpers and key_as_vector
   vector<int> vi{1, 2, 3};
   assert(picker::contains(vi, 2));


### PR DESCRIPTION
# Description

SystemVerilog simple identifiers can contain `$`, but Picker currently carries
that character into generated host-language members and DPI-C lookup names.
For an internal signal named `dpi_dollar.sig$1`, the baseline has two
independent failures:

1. The generated Python module contains
   `self.dpi_dollar_sig$1.BindDPIPtr(...)` and fails `py_compile` with
   `SyntaxError: invalid decimal literal`.
2. With Verilator 5.020, the final library exports
   `get_dpi_dollar_sig__0241...`, while Picker requests the absent raw name
   `get_dpi_dollar_sig$1...`.

This change introduces one shared DPI base-name mapping:

- preserve the historical dot-to-underscore spelling for ordinary names;
- when the flattened name contains `$`, encode the complete original logical
  path as lowercase hex behind the reserved `pickerdpix` prefix;
- case-insensitively encode names whose flattened form already starts with that
  prefix, preventing collisions after Go capitalizes generated fields;
- keep the prefix free of underscores so the signal tree treats each encoded
  name as one leaf rather than synthesizing a shared hierarchy;
- use the same mapped name in generated SystemVerilog, C++, Go, Java, Lua,
  Python, Scala, XPort registration, and the signal tree.

The SystemVerilog function and exported DPI-C name directly use the valid
encoded identifier; no simulator-specific export alias is required. Encoding
the complete path also keeps `a.b$` distinct from `a_b$`, which the historical
dot flattening alone would collapse.

Public GitHub issue/PR searches and a full enumeration of 96 issues/PRs plus
their public comments found no exact duplicate on 2026-09-01. Issue #10 is a
related but distinct Verilator character-encoding case for leading underscores;
PR #50 discusses `$` only in GSIM/FIRRTL parsing, and PR #58 only in Makefile
escaping. None covers dollar-bearing DPI identifiers or the emitted `__0241`
symbol mismatch.

Related: #10 (same general Verilator character-encoding area, but a distinct
identifier and failure path).

Dependencies: none.

## Type of change

- [x] Bug fix (names outside `$` and the reserved prefix remain unchanged)
- [ ] New feature
- [ ] Documentation update

# How Has This Been Tested?

### Baseline replay at `c100874`

The regression fixture and observation harness were overlaid while production
files remained at the base commit.

```text
python3 -m py_compile generated/__init__.py
=> status 1: SyntaxError: invalid decimal literal

raw get_dpi_dollar_sig$1... in final .so: missing
get_dpi_dollar_sig__0241... in final .so: present
```

The syntax-error output is retained in the local evidence bundle. The two
symbol-table lines are from the same earlier interactive baseline diagnostic;
its raw `nm` transcript was not retained, so reviewers should use the commands
above when independently replaying that part of the report.

### Patched end-to-end regression

```sh
make -C test export_internal_dollar_python
```

The test exports a design with `$` in external input/output names and an
internal signal, builds the generated Python/Verilator project, drives and
reads the external pins, reads the internal signal, and verifies the exact
encoded DPI symbol in the final shared library with `ctypes`.

```text
DPI_INTERNAL_DOLLAR_OK
DPI_INTERNAL_DOLLAR_SYMBOL=get_pickerdpix6470695f646f6c6c61722e7369672431xxPfBDHOLFPtd
[export-internal-dollar-python] OK
```

Additional checks:

- Release `test_picker_utils`: passed
- Release `test_codegen_sv_param`: passed
- generated Python/Verilator project: its field, lookup, XPort entry, DPI
  declaration, and final exported symbol all use the same encoded base name
- collision pair `a.b$` / `a_b$`: distinct in generated DPI declarations
- `a$` / `Pickerdpix6124` host fields and the `a$` / `b$` /
  `Picker_dpi.foo` / `Picker_dpi.bar` signal-tree roots remain unique after
  Go's first-letter capitalization
- fresh project compile with GCC 13.3: passed
- `git diff --check`: passed
- new shell script syntax check: passed

The baseline and patched generated-project logs contain the same pre-existing
`dut_base.hpp` printf-format, nested-Make jobserver, and CMake warnings; no new
warning is attributable to this change.

**Primary test configuration**

- OS: Ubuntu 24.04, aarch64
- GCC: 13.3.0
- CMake: 3.28.3
- Python: 3.12.3
- Verilator: 5.020

## Compatibility boundaries

- Existing generated names are unchanged unless their flattened spelling
  contains `$` or case-insensitively begins with the reserved `pickerdpix`
  prefix.
- Prefix-bearing names are intentionally re-encoded to keep the new namespace
  collision-free.
- Existing dot-versus-underscore collisions among ordinary names are outside
  this change.
- Dollar-bearing signals use one flat reserved encoded base in generated host
  fields and XPort keys. The underscore-free prefix also makes that base an
  atomic signal-tree leaf, avoiding Go case-normalization collisions; the
  public host name does not retain a human-readable hierarchy. The original
  logical path still selects the RTL signal.
- The encoding can approximately double identifier length; simulator-specific
  maximum identifier lengths were not stress-tested.
- Python received a real generated-project runtime test. C++, Go, Java, Lua,
  and Scala share the compiled mapping path, but their generated runtimes were
  not executed.
- VCS, UVS, GSIM, MEM_DIRECT, arrays, escaped identifiers, and punctuation
  other than `$` were not exercised.

# Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented the non-obvious encoding rule.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing relevant tests pass locally with my changes.
- [x] No downstream dependency changes are required.