### PR TITLE
test: exercise C++ assertions in Release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,10 @@ jobs:
           name: ${{ matrix.os }}-appdir
           path: AppDir
       
-      - name: Unit test (test_picker_utils)
+      - name: C++ unit tests
         run: |
-          cmake --build build --target test_picker_utils -j"$(nproc)"
-          ./build/bin/test_picker_utils
+          cmake --build build --parallel "$(nproc)"
+          ctest --test-dir build --output-on-failure --parallel "$(nproc)"
 
       - name: Smoke tests
         run: |

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,14 @@
 include_directories(../include)
 
+# Picker's Release builds define NDEBUG, while these tests use standard
+# assert() for their checks. Keep the optimized build but make test assertions
+# evaluate in every configuration.
+if(MSVC)
+    add_compile_options(/UNDEBUG)
+else()
+    add_compile_options(-UNDEBUG)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(parser_internalcfg)

--- a/test/test_codegen_filelist.cpp
+++ b/test/test_codegen_filelist.cpp
@@ -155,7 +155,9 @@ int main()
 
     assert(stderr_output.empty());
     assert(incdirs3.size() == 1);
-    assert(incdirs3.front() == base.string());
+    // Some standard libraries preserve a trailing separator for "base/.", so
+    // compare the existing directories rather than their spellings.
+    assert(fs::equivalent(fs::path(incdirs3.front()), base));
     assert(contains_line(ofilelist3, (base / "rtl1.sv").string()));
     assert(!contains_line(ofilelist3, (cwd_base / "rtl1.sv").string()));
 

--- a/test/test_parser_internalcfg_unit.cpp
+++ b/test/test_parser_internalcfg_unit.cpp
@@ -32,6 +32,7 @@ int main()
     assert(pins.size() == 3);
 
     bool found_a = false, found_b = false, found_c = false;
+    // Mapping keys are hierarchy components, including a scalar leaf's key.
     for (const auto &p : pins) {
         if (p.logic_pin == "top.sub.a") {
             found_a = true;
@@ -42,7 +43,7 @@ int main()
             found_b = true;
             assert(p.logic_pin_type == "output");
             assert(p.logic_pin_hb == -1);
-        } else if (p.logic_pin == "top.sub2.c") {
+        } else if (p.logic_pin == "top.sub2.key.c") {
             found_c = true;
             assert(p.logic_pin_type == "inout");
             assert(p.logic_pin_hb == 7);

--- a/test/test_picker_utils.cpp
+++ b/test/test_picker_utils.cpp
@@ -13,6 +13,10 @@ static void write_text(const std::string &p, const std::string &t) {
   o << t;
 }
 
+#ifdef NDEBUG
+#error "Picker test targets must be compiled with assertions enabled"
+#endif
+
 int main() {
   // trim/ltrim/rtrim and trim with custom pattern
   assert(picker::ltrim(string("  hi")) == "hi");


### PR DESCRIPTION
# Description

Picker configures its C++ tests as a Release build. The twelve C++ test files
contain 214 standard `assert(...)` checks, but Release defines `NDEBUG`, so
those conditions are not evaluated. The workflow also directly builds and
runs only `test_picker_utils`, even though the current configuration registers
fourteen Picker CTests (and four xcomm tests in the normal CI build).

This change:

- keeps Release optimization while undefining `NDEBUG` for targets created
  under `test/`;
- adds a compile-time guard so the CI-built `test_picker_utils` fails closed if
  assertions become disabled again;
- fixes two stale expectations exposed when the dormant assertions execute:
  an existing include directory is compared by filesystem identity, and the
  internal-config test expects the parser's existing map-key hierarchy;
- replaces the one-binary workflow command with a complete CMake build and
  parallel CTest run.

Production targets retain their normal Release flags and behavior.

Related context: #54 introduced the one-binary workflow command. #96 mentioned
the path-spelling assertion that becomes active here, but did not enable
Release assertions or run the complete CTest suite. This PR does not claim to
close either item.

PR #100 was discovered during the final publication refresh. It independently
adds two parser CTests, makes the same `top.sub2.key.c` expectation correction,
and normalizes the path covered here by `filesystem::equivalent`. It does not
enable assertions in Release or replace the one-binary CI command with CTest.
A synthetic merge of #100 and this exact head is clean: the CI and
`test/CMakeLists.txt` changes occupy separate hunks, and Git resolves the
identical parser expectation. If #100 merges first, this branch should be
rebased so the duplicate expectation drops out and the path assertion can be
reconsidered against #100's stricter normalization guarantee; the assertion
and CTest mechanisms remain independent.

Dependencies: no hard semantic dependency; the #100 overlap is described
above and currently merges automatically.

## Type of change

- [x] Bug fix (test and CI correctness; no production behavior change)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

# How Has This Been Tested?

Exact two-commit branch, Ubuntu 24.04 ARM64, GCC 13.3.0, CMake 3.28.3,
Release, `NO_BUILD_XSPCOMM=1`:

```text
configure: status 0
complete build: status 0, 100%
CTest: 14/14 passed
effective test flags: -O3 -DNDEBUG ... -UNDEBUG
```

Fail-closed controls:

```text
force -DNDEBUG after the candidate flags:
  compile status 1 at the new NDEBUG guard

replace non-primary test_parser_internalcfg_unit with /bin/false:
  old one-binary command: status 0
  targeted CTest: status 8
  restored test: status 0
```

A separate Ubuntu ARM64 integration stack with xcomm configured built to 100%
and passed root CTest 18/18 (four xcomm plus fourteen Picker tests). That is
coexistence evidence, not a claim that the other patches in that stack belong
to this PR.

Additional checks:

- `git diff --check`: passed
- branch is zero commits behind current `master@c100874`
- no public duplicate was found for Release/NDEBUG assertion enablement or
  complete CTest execution; the partial #100 overlap is disclosed above

## Compatibility boundary

- GCC was exercised in the retained isolated run.
- An earlier AppleClang run passed, but its raw log was not retained and is not
  part of the evidence claim above.
- The MSVC `/UNDEBUG` path was not executed; this PR does not claim new Windows
  support.
- In the current official configuration the new workflow reaches thirteen
  additional Picker tests and four configured xcomm tests. Future configured
  CTests will also be included by design.
- If #100 lands first, its two additional parser CTests will also be picked up
  automatically; the current 14-Picker/18-root counts are scoped to
  `master@c100874`.

# Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented the non-obvious test-flag requirement.
- [x] My changes generate no new warning attributable to this patch.
- [x] I have added a fail-closed guard and execution-reachability controls.
- [x] New and existing configured unit tests pass with the change.
- [x] No downstream dependency changes are required.
